### PR TITLE
feat: Basic Scrolling in Tab Menu

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 use eframe::egui;
+use egui::Vec2;
 
 fn main() -> Result<(), eframe::Error> {
     env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
@@ -137,6 +138,11 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
     ) {
         if ui.button("➕").clicked() {
             self.add_child_to = Some(tile_id);
+        }
+
+        if ui.button(">").clicked() {
+            let initial_delta = Vec2::new(5.0, 0.0);
+            ui.scroll_with_delta(initial_delta)
         }
     }
 

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -135,16 +135,14 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
         &mut self,
         _tiles: &egui_tiles::Tiles<Pane>,
         ui: &mut egui::Ui,
-        tile_id: egui_tiles::TileId,
+        _tile_id: egui_tiles::TileId,
         _tabs: &egui_tiles::Tabs,
         _scroll: Sender<f32>,
         _offset: Option<f32>
     ) {
-        // if _offset.is_some() && _offset.unwrap() > 45.0 {
         if ui.button("<").clicked() {
             _scroll.send(-45.0).unwrap();
         } 
-        // }
     }
 
     fn top_bar_rtl_ui(
@@ -161,7 +159,7 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
         }
 
         if ui.button(">").clicked() {
-            // Float value to move scroll by
+            // Integer value to move scroll by
             // +'ve is right
             // -'ve is left
             _scroll.send(45.0).unwrap();

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -135,9 +135,9 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
         _tile_id: egui_tiles::TileId,
         _tabs: &egui_tiles::Tabs,
         _offset: f32,
-        _scroll: &mut f32
+        _scroll: &mut f32,
     ) {
-        if ui.button("⏴").clicked() {           
+        if ui.button("⏴").clicked() {
             *_scroll += -45.0;
         }
     }
@@ -149,13 +149,13 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
         _tile_id: egui_tiles::TileId,
         _tabs: &egui_tiles::Tabs,
         _offset: f32,
-        _scroll: &mut f32 
+        _scroll: &mut f32,
     ) {
         // if ui.button("➕").clicked() {
         //     self.add_child_to = Some(tile_id);
         // }
 
-        if ui.button("⏵").clicked() {            
+        if ui.button("⏵").clicked() {
             // Integer value to move scroll by
             // +'ve is right
             // -'ve is left

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 use std::sync::mpsc::Sender;
+
 use eframe::egui;
 
 fn main() -> Result<(), eframe::Error> {
@@ -135,8 +136,8 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
         ui: &mut egui::Ui,
         _tile_id: egui_tiles::TileId,
         _tabs: &egui_tiles::Tabs,
-        _scroll: Sender<f32>,
-        _offset: Option<f32>,
+        _offset: f32,
+        _scroll: Sender<f32>
     ) {
         if ui.button("<").clicked() {
             _scroll.send(-45.0).unwrap();
@@ -147,14 +148,14 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
         &mut self,
         _tiles: &egui_tiles::Tiles<Pane>,
         ui: &mut egui::Ui,
-        tile_id: egui_tiles::TileId,
+        _tile_id: egui_tiles::TileId,
         _tabs: &egui_tiles::Tabs,
-        _scroll: Sender<f32>,
-        _offset: Option<f32>,
+        _offset: f32,
+        _scroll: Sender<f32>
     ) {
-        if ui.button("➕").clicked() {
-            self.add_child_to = Some(tile_id);
-        }
+        // if ui.button("➕").clicked() {
+        //     self.add_child_to = Some(tile_id);
+        // }
 
         if ui.button(">").clicked() {
             // Integer value to move scroll by

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,9 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 use std::sync::mpsc::Sender;
-
 use eframe::egui;
-use egui::Vec2;
 
 fn main() -> Result<(), eframe::Error> {
     env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -3,6 +3,7 @@
 use std::sync::mpsc::Sender;
 
 use eframe::egui;
+use egui::Button;
 
 fn main() -> Result<(), eframe::Error> {
     env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
@@ -130,38 +131,38 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
         format!("View {}", view.nr).into()
     }
 
-    fn top_bar_ltl_ui(
+    fn top_bar_left_ui(
         &mut self,
         _tiles: &egui_tiles::Tiles<Pane>,
         ui: &mut egui::Ui,
         _tile_id: egui_tiles::TileId,
         _tabs: &egui_tiles::Tabs,
         _offset: f32,
-        _scroll: Sender<f32>
+        _scroll: &mut f32
     ) {
-        if ui.button("<").clicked() {
-            _scroll.send(-45.0).unwrap();
+        if ui.button("⏴").clicked() {           
+            *_scroll += -45.0;
         }
     }
 
-    fn top_bar_rtl_ui(
+    fn top_bar_right_ui(
         &mut self,
         _tiles: &egui_tiles::Tiles<Pane>,
         ui: &mut egui::Ui,
         _tile_id: egui_tiles::TileId,
         _tabs: &egui_tiles::Tabs,
         _offset: f32,
-        _scroll: Sender<f32>
+        _scroll: &mut f32 
     ) {
         // if ui.button("➕").clicked() {
         //     self.add_child_to = Some(tile_id);
         // }
 
-        if ui.button(">").clicked() {
+        if ui.button("⏵").clicked() {            
             // Integer value to move scroll by
             // +'ve is right
             // -'ve is left
-            _scroll.send(45.0).unwrap();
+            *_scroll += 45.0;
         }
     }
 

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
+use std::sync::mpsc::Sender;
+
 use eframe::egui;
 use egui::Vec2;
 
@@ -129,20 +131,40 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
         format!("View {}", view.nr).into()
     }
 
+    fn top_bar_ltl_ui(
+        &mut self,
+        _tiles: &egui_tiles::Tiles<Pane>,
+        ui: &mut egui::Ui,
+        tile_id: egui_tiles::TileId,
+        _tabs: &egui_tiles::Tabs,
+        _scroll: Sender<f32>,
+        _offset: Option<f32>
+    ) {
+        // if _offset.is_some() && _offset.unwrap() > 45.0 {
+        if ui.button("<").clicked() {
+            _scroll.send(-45.0).unwrap();
+        } 
+        // }
+    }
+
     fn top_bar_rtl_ui(
         &mut self,
         _tiles: &egui_tiles::Tiles<Pane>,
         ui: &mut egui::Ui,
         tile_id: egui_tiles::TileId,
         _tabs: &egui_tiles::Tabs,
+        _scroll: Sender<f32>,
+        _offset: Option<f32>
     ) {
         if ui.button("➕").clicked() {
             self.add_child_to = Some(tile_id);
         }
 
         if ui.button(">").clicked() {
-            let initial_delta = Vec2::new(5.0, 0.0);
-            ui.scroll_with_delta(initial_delta)
+            // Float value to move scroll by
+            // +'ve is right
+            // -'ve is left
+            _scroll.send(45.0).unwrap();
         }
     }
 

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -138,11 +138,11 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
         _tile_id: egui_tiles::TileId,
         _tabs: &egui_tiles::Tabs,
         _scroll: Sender<f32>,
-        _offset: Option<f32>
+        _offset: Option<f32>,
     ) {
         if ui.button("<").clicked() {
             _scroll.send(-45.0).unwrap();
-        } 
+        }
     }
 
     fn top_bar_rtl_ui(
@@ -152,7 +152,7 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
         tile_id: egui_tiles::TileId,
         _tabs: &egui_tiles::Tabs,
         _scroll: Sender<f32>,
-        _offset: Option<f32>
+        _offset: Option<f32>,
     ) {
         if ui.button("➕").clicked() {
             self.add_child_to = Some(tile_id);

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,9 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use std::sync::mpsc::Sender;
-
 use eframe::egui;
-use egui::Button;
 
 fn main() -> Result<(), eframe::Error> {
     env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -1,3 +1,5 @@
+use std::sync::mpsc::Sender;
+
 use egui::{
     vec2, Color32, Id, Rect, Response, Rgba, Sense, Stroke, TextStyle, Ui, Visuals, WidgetText,
 };
@@ -113,6 +115,21 @@ pub trait Behavior<Pane> {
         _ui: &mut Ui,
         _tile_id: TileId,
         _tabs: &crate::Tabs,
+        _scroll: Sender<f32>,
+        _offset: Option<f32>
+    ) {
+        // if ui.button("➕").clicked() {
+        // }
+    }
+
+    fn top_bar_ltl_ui(
+        &mut self,
+        _tiles: &Tiles<Pane>,
+        _ui: &mut Ui,
+        _tile_id: TileId,
+        _tabs: &crate::Tabs,
+        _scroll: Sender<f32>,
+        _offset: Option<f32>
     ) {
         // if ui.button("➕").clicked() {
         // }

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -109,27 +109,27 @@ pub trait Behavior<Pane> {
     /// You can use this to, for instance, add a button for adding new tabs.
     ///
     /// The widgets will be added right-to-left.
-    fn top_bar_rtl_ui(
+    fn top_bar_right_ui(
         &mut self,
         _tiles: &Tiles<Pane>,
         _ui: &mut Ui,
         _tile_id: TileId,
         _tabs: &crate::Tabs,
         _offset: f32,
-        _scroll: Sender<f32>,
+        _scroll: &mut f32,
     ) {
         // if ui.button("➕").clicked() {
         // }
     }
 
-    fn top_bar_ltl_ui(
+    fn top_bar_left_ui(
         &mut self,
         _tiles: &Tiles<Pane>,
         _ui: &mut Ui,
         _tile_id: TileId,
         _tabs: &crate::Tabs,
         _offset: f32,
-        _scroll: Sender<f32>,
+        _scroll: &mut f32,
     ) {
         // if ui.button("➕").clicked() {
         // }

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -115,8 +115,8 @@ pub trait Behavior<Pane> {
         _ui: &mut Ui,
         _tile_id: TileId,
         _tabs: &crate::Tabs,
+        _offset: f32,
         _scroll: Sender<f32>,
-        _offset: Option<f32>,
     ) {
         // if ui.button("➕").clicked() {
         // }
@@ -128,8 +128,8 @@ pub trait Behavior<Pane> {
         _ui: &mut Ui,
         _tile_id: TileId,
         _tabs: &crate::Tabs,
+        _offset: f32,
         _scroll: Sender<f32>,
-        _offset: Option<f32>,
     ) {
         // if ui.button("➕").clicked() {
         // }

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -1,5 +1,3 @@
-use std::sync::mpsc::Sender;
-
 use egui::{
     vec2, Color32, Id, Rect, Response, Rgba, Sense, Stroke, TextStyle, Ui, Visuals, WidgetText,
 };

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -116,7 +116,7 @@ pub trait Behavior<Pane> {
         _tile_id: TileId,
         _tabs: &crate::Tabs,
         _scroll: Sender<f32>,
-        _offset: Option<f32>
+        _offset: Option<f32>,
     ) {
         // if ui.button("➕").clicked() {
         // }
@@ -129,7 +129,7 @@ pub trait Behavior<Pane> {
         _tile_id: TileId,
         _tabs: &crate::Tabs,
         _scroll: Sender<f32>,
-        _offset: Option<f32>
+        _offset: Option<f32>,
     ) {
         // if ui.button("➕").clicked() {
         // }

--- a/src/container/linear.rs
+++ b/src/container/linear.rs
@@ -110,7 +110,7 @@ impl Linear {
     ///
     /// The `fraction` is the fraction of the total width that the first child should get.
     pub fn new_binary(dir: LinearDir, children: [TileId; 2], fraction: f32) -> Self {
-        debug_assert!(0.0 <= fraction && fraction <= 1.0);
+        debug_assert!((0.0..=1.0).contains(&fraction));
         let mut slf = Self {
             children: children.into(),
             dir,

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -1,3 +1,5 @@
+use std::default;
+
 use egui::{scroll_area::ScrollBarVisibility, vec2, Rect, Vec2};
 
 use crate::{
@@ -20,7 +22,10 @@ struct ScrollState {
     pub offset: Vec2,
     pub consumed: Vec2,
     pub available: Vec2,
-    pub offset_delta: Vec2  
+    pub offset_delta: Vec2,
+    
+    pub prev_frame_left: bool,
+    pub prev_frame_right: bool
 }
 
 impl Tabs {
@@ -118,7 +123,7 @@ impl Tabs {
             ui.spacing_mut().item_spacing.x = 0.0; // Tabs have spacing built-in
 
             let mut scroll_state: ScrollState = ui.ctx().memory_mut(|m| m.data.get_temp::<ScrollState>(id)).unwrap();
-            
+
             if scroll_state.consumed.x > scroll_state.available.x {
                 behavior.top_bar_right_ui(
                     &tree.tiles,
@@ -132,90 +137,122 @@ impl Tabs {
 
             ui.set_clip_rect(ui.available_rect_before_wrap()); // Don't cover the `rtl_ui` buttons.
 
-            let total_width = ui.available_width();
-            let mut scroll_area_size = Vec2::ZERO;
-            scroll_area_size.x = total_width - 25.0;
-            scroll_area_size.y = ui.available_height();
+            println!("{} {}", scroll_state.offset.x, scroll_state.prev_frame_left);
 
-            let mut area = egui::ScrollArea::horizontal()
-                .scroll_bar_visibility(ScrollBarVisibility::AlwaysHidden)
-                .max_width(ui.available_width()-25.0);
+            let mut consume = ui.available_width();
 
-            {
-                // Max is: [`ui.available_width()`]
-                if scroll_state.offset_delta.x >= (ui.available_width()) {
-                    scroll_state.offset_delta.x = ui.available_width();
-                }
+            if scroll_state.offset.x > 20.0 {
+                // if !scroll_state.prev_frame_left {
+                //     scroll_state.offset_delta.x -= 20.0;
+                // }
 
-                if scroll_state.offset_delta.x < 0.0 {
-                    scroll_state.offset_delta.x = 0.0;
-                }
+                scroll_state.prev_frame_left = true;
 
-                area = area.to_owned().horizontal_scroll_offset(scroll_state.offset.x + scroll_state.offset_delta.x);
-
-                scroll_state.offset_delta = Vec2::ZERO;
+                consume -= 20.0;
+            }else if scroll_state.offset.x > 0.0 {
+                consume -= scroll_state.offset.x;
+            }else {
+                scroll_state.prev_frame_left = false;
             }
 
-            let output = area.show_viewport(ui, |ui, _| {
-                ui.allocate_ui_with_layout(scroll_area_size, egui::Layout::left_to_right(egui::Align::Center), |ui| {
-                    if !tree.is_root(tile_id) {
-                        // Make the background behind the buttons draggable (to drag the parent container tile):
-                        if ui
-                            .interact(
-                                ui.max_rect(),
-                                ui.id().with("background"),
-                                egui::Sense::drag(),
-                            )
-                            .on_hover_cursor(egui::CursorIcon::Grab)
-                            .drag_started()
-                        {
-                            ui.memory_mut(|mem| mem.set_dragged_id(tile_id.id()));
-                        }
+            // let consume = if scroll_state.offset.x > 20.0 || scroll_state.prev_frame_left {
+            //     if !scroll_state.prev_frame_left {
+            //         scroll_state.offset_delta.x -= 20.0;
+            //         scroll_state.prev_frame_left = true;
+            //     }
+                
+            //     if scroll_state.offset.x == 0.0 {
+            //         scroll_state.prev_frame_left = false;
+            //     }
+                
+            //     ui.available_width() - 20.0 
+            // } else {
+            //     scroll_state.prev_frame_left = false;
+            //     ui.available_width() 
+            // };
+
+            let mut scroll_area_size = Vec2::ZERO;
+            scroll_area_size.x = consume;
+            scroll_area_size.y = ui.available_height();
+
+            ui.allocate_ui_with_layout(scroll_area_size, egui::Layout::left_to_right(egui::Align::Center), | ui | {
+                let mut area = egui::ScrollArea::horizontal()
+                .scroll_bar_visibility(ScrollBarVisibility::AlwaysHidden)
+                .max_width(consume);
+
+                {
+                    // Max is: [`ui.available_width()`]
+                    if scroll_state.offset_delta.x >= ui.available_width() {
+                        scroll_state.offset_delta.x = ui.available_width();
                     }
 
-                    for (i, &child_id) in self.children.iter().enumerate() {
-                        let is_being_dragged = is_being_dragged(ui.ctx(), child_id);
+                    area = area.to_owned().horizontal_scroll_offset(scroll_state.offset.x + scroll_state.offset_delta.x);
 
-                        let selected = self.is_active(child_id);
-                        let id = child_id.id();
-
-                        let response = behavior.tab_ui(
-                            &tree.tiles,
-                            ui,
-                            id,
-                            child_id,
-                            selected,
-                            is_being_dragged,
-                        );
-                        let response = response.on_hover_cursor(egui::CursorIcon::Grab);
-                        if response.clicked() {
-                            next_active = Some(child_id);
-                            response.scroll_to_me(None)
-                        }
-
-                        if let Some(mouse_pos) = drop_context.mouse_pos {
-                            if drop_context.dragged_tile_id.is_some()
-                                && response.rect.contains(mouse_pos)
+                    // Reset delta after use
+                    scroll_state.offset_delta = Vec2::ZERO;
+                }
+                
+                let output = area.show_viewport(ui, |ui, _ | {
+                    ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
+                        if !tree.is_root(tile_id) {
+                            // Make the background behind the buttons draggable (to drag the parent container tile):
+                            if ui
+                                .interact(
+                                    ui.max_rect(),
+                                    ui.id().with("background"),
+                                    egui::Sense::drag(),
+                                )
+                                .on_hover_cursor(egui::CursorIcon::Grab)
+                                .drag_started()
                             {
-                                // Expand this tab - maybe the user wants to drop something into it!
-                                next_active = Some(child_id);
+                                ui.memory_mut(|mem| mem.set_dragged_id(tile_id.id()));
                             }
                         }
 
-                        button_rects.insert(child_id, response.rect);
-                        if is_being_dragged {
-                            dragged_index = Some(i);
+                        for (i, &child_id) in self.children.iter().enumerate() {
+                            let is_being_dragged = is_being_dragged(ui.ctx(), child_id);
+
+                            let selected = self.is_active(child_id);
+                            let id = child_id.id();
+
+                            let response = behavior.tab_ui(
+                                &tree.tiles,
+                                ui,
+                                id,
+                                child_id,
+                                selected,
+                                is_being_dragged,
+                            );
+                            let response = response.on_hover_cursor(egui::CursorIcon::Grab);
+                            if response.clicked() {
+                                next_active = Some(child_id);
+                                response.scroll_to_me(None)
+                            }
+
+                            if let Some(mouse_pos) = drop_context.mouse_pos {
+                                if drop_context.dragged_tile_id.is_some()
+                                    && response.rect.contains(mouse_pos)
+                                {
+                                    // Expand this tab - maybe the user wants to drop something into it!
+                                    next_active = Some(child_id);
+                                }
+                            }
+
+                            button_rects.insert(child_id, response.rect);
+                            if is_being_dragged {
+                                dragged_index = Some(i);
+                            }
                         }
-                    }
+                    });
                 });
+
+                scroll_state.offset = output.state.offset;
+                scroll_state.consumed = output.content_size;
+                scroll_state.available = output.inner_rect.size();
             });
-
+            
             if scroll_state.offset.x > 0.0 {
-                let mut scroll_area_size = Vec2::ZERO;
-                scroll_area_size.x = 25.0;
-                scroll_area_size.y = ui.available_height();
-
-                ui.allocate_ui_with_layout(scroll_area_size, egui::Layout::right_to_left(egui::Align::Center), | ui | {
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), | ui | {
                     behavior.top_bar_left_ui(
                         &tree.tiles, ui, tile_id, 
                         self, scroll_state.offset.x,
@@ -223,10 +260,6 @@ impl Tabs {
                     );
                 });
             }
-
-            scroll_state.offset = output.state.offset;
-            scroll_state.consumed = output.content_size;
-            scroll_state.available = output.inner_rect.size();
 
             ui.ctx().memory_mut(|m| m.data.insert_temp(id, scroll_state));
         });

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -1,4 +1,4 @@
-use egui::{scroll_area::ScrollBarVisibility, vec2, Rect, Sense};
+use egui::{scroll_area::ScrollBarVisibility, vec2, Rect};
 
 use crate::{
     is_being_dragged, Behavior, ContainerInsertion, DropContext, InsertionPoint, SimplifyAction,

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -1,5 +1,3 @@
-use std::default;
-
 use egui::{scroll_area::ScrollBarVisibility, vec2, Rect, Vec2};
 
 use crate::{

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -90,13 +90,10 @@ impl Tabs {
 
         let id = ui.make_persistent_id(tile_id);
 
-        println!("START:: LOC:{{{:?}}}, VAL:{:?}", id, 0.0);
         ui.ctx().memory_mut(
             |m|
             if m.data.get_temp::<f32>(id).is_none() {
                 m.data.insert_temp(id, scroll_length)
-            }else {
-                println!("Received: {:?}", m.data.get_temp::<f32>(id).unwrap());
             }
         );
 
@@ -133,7 +130,6 @@ impl Tabs {
                 if let Some(offset) = offset {
                     let mut offset = offset;
 
-                    println!("GOT UPDATE: {}:[{}] FROM LOC:{{{:?}}} MAX:{}", offset, new_position, id, ui.available_width());
                     offset += new_position;
 
                     // Max is: [`ui.available_width()`]

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -23,7 +23,7 @@ struct ScrollState {
     pub consumed: Vec2,
     pub available: Vec2,
     pub offset_delta: Vec2,
-    
+
     pub prev_frame_left: bool,
     pub prev_frame_right: bool
 }
@@ -137,20 +137,21 @@ impl Tabs {
 
             ui.set_clip_rect(ui.available_rect_before_wrap()); // Don't cover the `rtl_ui` buttons.
 
-            println!("{} {}", scroll_state.offset.x, scroll_state.prev_frame_left);
-
             let mut consume = ui.available_width();
 
             if scroll_state.offset.x > 20.0 {
-                // if !scroll_state.prev_frame_left {
-                //     scroll_state.offset_delta.x -= 20.0;
-                // }
+                if !scroll_state.prev_frame_left {
+                    scroll_state.offset_delta.x += 20.0;
+                }
 
                 scroll_state.prev_frame_left = true;
 
                 consume -= 20.0;
             }else if scroll_state.offset.x > 0.0 {
-                consume -= scroll_state.offset.x;
+                if scroll_state.prev_frame_left {
+                    scroll_state.offset.x -= 20.0;
+                }
+                // consume -= scroll_state.offset.x;
             }else {
                 scroll_state.prev_frame_left = false;
             }

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -137,40 +137,28 @@ impl Tabs {
 
             ui.set_clip_rect(ui.available_rect_before_wrap()); // Don't cover the `rtl_ui` buttons.
 
+            const LEFT_FRAME_SIZE: f32 = 20.0;
+
             let mut consume = ui.available_width();
 
-            if scroll_state.offset.x > 20.0 {
+            if scroll_state.offset.x > LEFT_FRAME_SIZE {
                 if !scroll_state.prev_frame_left {
-                    scroll_state.offset_delta.x += 20.0;
+                    scroll_state.offset_delta.x += LEFT_FRAME_SIZE;
                 }
 
                 scroll_state.prev_frame_left = true;
 
-                consume -= 20.0;
+                consume -= LEFT_FRAME_SIZE;
             }else if scroll_state.offset.x > 0.0 {
                 if scroll_state.prev_frame_left {
-                    scroll_state.offset.x -= 20.0;
+                    scroll_state.offset.x -= LEFT_FRAME_SIZE;
                 }
+
+                // Uncomment the following for an ~animated~ reveal.
                 // consume -= scroll_state.offset.x;
             }else {
                 scroll_state.prev_frame_left = false;
             }
-
-            // let consume = if scroll_state.offset.x > 20.0 || scroll_state.prev_frame_left {
-            //     if !scroll_state.prev_frame_left {
-            //         scroll_state.offset_delta.x -= 20.0;
-            //         scroll_state.prev_frame_left = true;
-            //     }
-                
-            //     if scroll_state.offset.x == 0.0 {
-            //         scroll_state.prev_frame_left = false;
-            //     }
-                
-            //     ui.available_width() - 20.0 
-            // } else {
-            //     scroll_state.prev_frame_left = false;
-            //     ui.available_width() 
-            // };
 
             let mut scroll_area_size = Vec2::ZERO;
             scroll_area_size.x = consume;

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -1,4 +1,4 @@
-use egui::{scroll_area::ScrollBarVisibility, vec2, Rect, Vec2, Pos2};
+use egui::{scroll_area::ScrollBarVisibility, vec2, Rect, Vec2};
 
 use crate::{
     is_being_dragged, Behavior, ContainerInsertion, DropContext, InsertionPoint, SimplifyAction,
@@ -211,23 +211,18 @@ impl Tabs {
             });
 
             if scroll_state.offset.x > 0.0 {
-                
+                let mut scroll_area_size = Vec2::ZERO;
+                scroll_area_size.x = 25.0;
+                scroll_area_size.y = ui.available_height();
+
+                ui.allocate_ui_with_layout(scroll_area_size, egui::Layout::right_to_left(egui::Align::Center), | ui | {
+                    behavior.top_bar_left_ui(
+                        &tree.tiles, ui, tile_id, 
+                        self, scroll_state.offset.x,
+                        &mut scroll_state.offset_delta.x
+                    );
+                });
             }
-
-            let total_width = ui.available_width();
-            let mut scroll_area_size = Vec2::ZERO;
-            scroll_area_size.x = 25.0;
-            scroll_area_size.y = ui.available_height();
-
-            println!("W: {:?}", scroll_area_size);
-
-            ui.allocate_ui_with_layout(scroll_area_size, egui::Layout::right_to_left(egui::Align::Center), | ui | {
-                behavior.top_bar_left_ui(
-                    &tree.tiles, ui, tile_id, 
-                    self, scroll_state.offset.x,
-                    &mut scroll_state.offset_delta.x
-                );
-            });
 
             scroll_state.offset = output.state.offset;
             scroll_state.consumed = output.content_size;


### PR DESCRIPTION
I don't usually do PR's, but I thought I'd have a crack at this one.
This PR Addresses #2 in basic terms, as follows:

### This PR contains:
1. Scrolling within tab view using scroll wheel
2.  Icons for moving back and forth for those without scroll wheel (Implemented in menubar) 
> Note: Added `top_bar_ltl_ui` for the `<` icon incase left alignment is prefered.
3. `.click()` for tab elements will scroll them into view.

### Implementation:
Using a MPSC (`std::sync::mpsc::channel::<f32>()`) to share data between the menu elements `>` and `<`, and the `ScrollArea`. The tab menu is now wrapped in a `ScrollArea`with an always hidden scroll bar. 

### Issues with Implementation:
I am not experienced enough with `egui` to know how to find the fitted width of an element's contents, and so scrolling rightward will permit over-scroll in some cases as the `ui.available_width()` is greater than the consumed width. 

Furthermore, as the scroll area's offset is stored using `ctx().memory_mut()`, I am unsure of how to update this value to match the scroll when using a mouse - and so, after using the mouse to scroll, and again using the chevrons, the scroll will jump to its previous state. Any help on this is much appreciated.