### PR TITLE
Invisible tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased](https://github.com/rerun-io/rerun/compare/latest...HEAD)
 * Add support for invisible tiles
+* `PartialEq` for `Tiles` now ignore internal state
 
 
 ## 0.1.0 - Initial Release - 2023-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add support for invisible tiles
 * `PartialEq` for `Tiles` now ignore internal state
 * Add `Tiles::find_pane`
+* Add `Tiles::remove_recursively`
 
 
 ## 0.1.0 - Initial Release - 2023-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# `egui_tiles` Changelog
+
+## [Unreleased](https://github.com/rerun-io/rerun/compare/latest...HEAD)
+* Add support for invisible tiles
+
+
+## 0.1.0 - Initial Release - 2023-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased](https://github.com/rerun-io/rerun/compare/latest...HEAD)
 * Add support for invisible tiles
-* `PartialEq` for `Tiles` now ignore internal state
+* `PartialEq` for `Tiles` now ignores internal state
 * Add `Tiles::find_pane`
 * Add `Tiles::remove_recursively`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/rerun-io/rerun/compare/latest...HEAD)
 * Add support for invisible tiles
 * `PartialEq` for `Tiles` now ignore internal state
+* Add `Tiles::find_pane`
 
 
 ## 0.1.0 - Initial Release - 2023-05-24

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,10 @@ all-features = true
 
 
 [dependencies]
-ahash = "0.8"
+ahash = { version = "0.8.1", default-features = false, features = [
+  "no-rng", # we don't need DOS-protection for what we use ahash for
+  "std",
+] }
 egui = { version = "0.22", default-features = false }
 itertools = "0.11"
 log = { version = "0.4", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,10 @@ all-features = true
 
 
 [dependencies]
+ahash = "0.8"
 egui = { version = "0.22", default-features = false }
-getrandom = { version = "0.2", features = ["js"] }
-itertools = "0.10"
+itertools = "0.11"
 log = { version = "0.4", features = ["std"] }
-nohash-hasher = "0.2"
-rand = { version = "0.8.5", features = ["getrandom", "small_rng"] }
 serde = { version = "1", features = ["derive"] }
 
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Supports:
 ### Comparison with [egui_dock](https://github.com/Adanos020/egui_dock)
 [egui_dock](https://github.com/Adanos020/egui_dock) is an excellent crate serving similar needs. `egui_tiles` aims to become a more flexible and feature-rich alternative to `egui_dock`.
 
-`egui_dock` only supports binary splits (left/right or top/bottom), while `egui_tiles` support full horizontal and vertical layouts, as well as grid layouts. `egui_tiles` is also strives to be more customizable, enabling users to override the default style and behavior by implementing methods on a `Behavior` `trait`.
+`egui_dock` only supports binary splits (left/right or top/bottom), while `egui_tiles` support full horizontal and vertical layouts, as well as grid layouts. `egui_tiles` also strives to be more customizable, enabling users to override the default style and behavior by implementing methods on a `Behavior` `trait`.
 
 `egui_dock` supports some features that `egui_tiles` does not yet support, such as close-buttons on each tab, and built-in scroll areas.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,10 @@
+# Release Checklist
+
+* [ ] `git commit -m 'Release 0.x.0 - summary'`
+* [ ] `cargo publish`
+* [ ] `git tag -a 0.x.0 -m 'Release 0.x.0 - summary'`
+* [ ] `git pull --tags && git tag -d latest && git tag -a latest -m 'Latest release' && git push --tags origin latest --force`
+* [ ] `git push && git push --tags`
+* [ ] Do a GitHub release: https://github.com/rerun-io/egui_tiles/releases/new
+* [ ] Wait for documentation to build: https://docs.rs/releases/queue
+* [ ] Post on Twitter

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -265,7 +265,7 @@ fn tree_ui(
         behavior.tab_title_for_tile(tiles, tile_id).text()
     );
 
-    let Some(mut tile) = tiles.tiles.remove(&tile_id) else {
+    let Some(mut tile) = tiles.remove(tile_id) else {
         log::warn!("Missing tile {tile_id:?}");
         return;
     };
@@ -304,5 +304,5 @@ fn tree_ui(
         }
     });
 
-    tiles.tiles.insert(tile_id, tile);
+    tiles.insert(tile_id, tile);
 }

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -270,30 +270,39 @@ fn tree_ui(
         return;
     };
 
-    egui::CollapsingHeader::new(text)
-        .id_source((tile_id, "tree"))
-        .default_open(true)
-        .show(ui, |ui| match &mut tile {
-            egui_tiles::Tile::Pane(_) => {}
-            egui_tiles::Tile::Container(container) => {
-                let mut kind = container.kind();
-                egui::ComboBox::from_label("Kind")
-                    .selected_text(format!("{kind:?}"))
-                    .show_ui(ui, |ui| {
-                        for typ in egui_tiles::ContainerKind::ALL {
-                            ui.selectable_value(&mut kind, typ, format!("{typ:?}"))
-                                .clicked();
-                        }
-                    });
-                if kind != container.kind() {
-                    container.set_kind(kind);
-                }
-
-                for &child in container.children() {
-                    tree_ui(ui, behavior, tiles, child);
-                }
+    let default_open = true;
+    egui::collapsing_header::CollapsingState::load_with_default_open(
+        ui.ctx(),
+        egui::Id::new((tile_id, "tree")),
+        default_open,
+    )
+    .show_header(ui, |ui| {
+        ui.label(text);
+        let mut visible = tiles.is_visible(tile_id);
+        ui.checkbox(&mut visible, "Visible");
+        tiles.set_visible(tile_id, visible);
+    })
+    .body(|ui| match &mut tile {
+        egui_tiles::Tile::Pane(_) => {}
+        egui_tiles::Tile::Container(container) => {
+            let mut kind = container.kind();
+            egui::ComboBox::from_label("Kind")
+                .selected_text(format!("{kind:?}"))
+                .show_ui(ui, |ui| {
+                    for typ in egui_tiles::ContainerKind::ALL {
+                        ui.selectable_value(&mut kind, typ, format!("{typ:?}"))
+                            .clicked();
+                    }
+                });
+            if kind != container.kind() {
+                container.set_kind(kind);
             }
-        });
+
+            for &child in container.children() {
+                tree_ui(ui, behavior, tiles, child);
+            }
+        }
+    });
 
     tiles.tiles.insert(tile_id, tile);
 }

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -265,6 +265,7 @@ fn tree_ui(
         behavior.tab_title_for_tile(tiles, tile_id).text()
     );
 
+    // Temporarily remove the tile to circumvent the borrowchecker
     let Some(mut tile) = tiles.remove(tile_id) else {
         log::warn!("Missing tile {tile_id:?}");
         return;
@@ -304,5 +305,6 @@ fn tree_ui(
         }
     });
 
+    // Put the tile back
     tiles.insert(tile_id, tile);
 }

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -239,7 +239,6 @@ impl eframe::App for MyApp {
             ui.monospace(&tree_debug);
             if self.last_tree_debug != tree_debug {
                 self.last_tree_debug = tree_debug;
-                log::debug!("{}", self.last_tree_debug);
             }
         });
 

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -238,14 +238,13 @@ pub trait Behavior<Pane> {
     ///
     /// The `rect` is the available space for the grid,
     /// and `gap` is the distance between each column and row.
-    fn grid_auto_column_count(
-        &self,
-        _tiles: &Tiles<Pane>,
-        children: &[TileId],
-        rect: Rect,
-        gap: f32,
-    ) -> usize {
-        num_columns_heuristic(children.len(), rect, gap, self.ideal_tile_aspect_ratio())
+    fn grid_auto_column_count(&self, num_visible_children: usize, rect: Rect, gap: f32) -> usize {
+        num_columns_heuristic(
+            num_visible_children,
+            rect,
+            gap,
+            self.ideal_tile_aspect_ratio(),
+        )
     }
 
     /// When using [`crate::GridLayout::Auto`], what is the ideal aspect ratio of a tile?

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -20,7 +20,7 @@ pub trait Behavior<Pane> {
     /// The default implementation calls [`Self::tab_title_for_pane`] for panes and
     /// uses the name of the [`crate::ContainerKind`] for [`crate::Container`]s.
     fn tab_title_for_tile(&mut self, tiles: &Tiles<Pane>, tile_id: TileId) -> WidgetText {
-        if let Some(tile) = tiles.tiles.get(&tile_id) {
+        if let Some(tile) = tiles.get(tile_id) {
             match tile {
                 Tile::Pane(pane) => self.tab_title_for_pane(pane),
                 Tile::Container(container) => format!("{:?}", container.kind()).into(),

--- a/src/container/grid.rs
+++ b/src/container/grid.rs
@@ -66,7 +66,7 @@ pub struct Grid {
     /// We allow holes (for easier drag-dropping).
     children: Vec<Option<TileId>>,
 
-    /// Determins the number of columns.
+    /// Determines the number of columns.
     pub layout: GridLayout,
 
     /// Share of the available width assigned to each column.
@@ -162,7 +162,7 @@ impl Grid {
         behavior: &mut dyn Behavior<Pane>,
         rect: Rect,
     ) {
-        // clea up any empty holes at the end
+        // clean up any empty holes at the end
         while self.children.last() == Some(&None) {
             self.children.pop();
         }

--- a/src/container/grid.rs
+++ b/src/container/grid.rs
@@ -64,9 +64,10 @@ pub struct Grid {
     /// The order of the children, row-major.
     ///
     /// We allow holes (for easier drag-dropping).
+    /// We collapse all holes if they become too numerous.
     children: Vec<Option<TileId>>,
 
-    /// Determines the number of columns.
+    /// Determins the number of columns.
     pub layout: GridLayout,
 
     /// Share of the available width assigned to each column.
@@ -91,8 +92,8 @@ impl PartialEq for Grid {
             layout,
             col_shares,
             row_shares,
-            col_ranges: _, // ignored because they are recomputed
-            row_ranges: _, // ignored because they are recomputed
+            col_ranges: _, // ignored because they are recomputed each frame
+            row_ranges: _, // ignored because they are recomputed each frame
         } = self;
 
         layout == &other.layout

--- a/src/container/grid.rs
+++ b/src/container/grid.rs
@@ -61,7 +61,7 @@ pub enum GridLayout {
 }
 
 /// A grid of tiles.
-#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct Grid {
     pub children: Vec<TileId>,
 
@@ -84,6 +84,26 @@ pub struct Grid {
     /// ui point y ranges for each row, recomputed during layout
     #[serde(skip)]
     row_ranges: Vec<Rangef>,
+}
+
+impl PartialEq for Grid {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            children,
+            layout,
+            locations,
+            col_shares,
+            row_shares,
+            col_ranges: _, // ignored because they are recomputed
+            row_ranges: _, // ignored because they are recomputed
+        } = self;
+
+        layout == &other.layout
+            && children == &other.children
+            && locations == &other.locations
+            && col_shares == &other.col_shares
+            && row_shares == &other.row_shares
+    }
 }
 
 impl Grid {

--- a/src/container/grid.rs
+++ b/src/container/grid.rs
@@ -40,7 +40,7 @@ pub struct Grid {
     /// We collapse all holes if they become too numerous.
     children: Vec<Option<TileId>>,
 
-    /// Determins the number of columns.
+    /// Determines the number of columns.
     pub layout: GridLayout,
 
     /// Share of the available width assigned to each column.

--- a/src/container/grid.rs
+++ b/src/container/grid.rs
@@ -6,33 +6,6 @@ use crate::{
     Tiles, Tree,
 };
 
-/// A location in a grid (row and column).
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    serde::Serialize,
-    serde::Deserialize,
-)]
-pub struct GridLoc {
-    // Row first for sorting
-    pub row: usize,
-    pub col: usize,
-}
-
-impl GridLoc {
-    #[inline]
-    pub fn from_col_row(col: usize, row: usize) -> Self {
-        Self { col, row }
-    }
-}
-
 /// How to lay out the children of a grid.
 #[derive(
     Clone,

--- a/src/container/grid.rs
+++ b/src/container/grid.rs
@@ -151,7 +151,7 @@ impl Grid {
     }
 
     fn collapse_holes(&mut self) {
-        log::debug!("Collaping grid holes");
+        log::trace!("Collaping grid holes");
         self.children.retain(|child| child.is_some());
     }
 

--- a/src/container/linear.rs
+++ b/src/container/linear.rs
@@ -11,6 +11,8 @@ use crate::{
 /// How large of a share of space each child has, on a 1D axis.
 ///
 /// Used for [`Linear`] containers (horizontal and vertical).
+///
+/// Also contains the shares for currently invisible tiles.
 #[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Shares {
     /// How large of a share each child has.
@@ -44,10 +46,6 @@ impl Shares {
 
     pub fn retain(&mut self, keep: impl Fn(TileId) -> bool) {
         self.shares.retain(|&child, _| keep(child));
-    }
-
-    pub fn sum(&self) -> f32 {
-        self.shares.values().sum()
     }
 }
 
@@ -106,6 +104,14 @@ impl Linear {
         }
     }
 
+    fn visible_childre<Pane>(&mut self, tiles: &Tiles<Pane>) -> Vec<TileId> {
+        self.children
+            .iter()
+            .copied()
+            .filter(|&child_id| tiles.is_visible(child_id))
+            .collect()
+    }
+
     /// Create a binary split with the given split ratio in the 0.0 - 1.0 range.
     ///
     /// The `fraction` is the fraction of the total width that the first child should get.
@@ -153,15 +159,17 @@ impl Linear {
         behavior: &mut dyn Behavior<Pane>,
         rect: Rect,
     ) {
-        let num_gaps = self.children.len().saturating_sub(1);
+        let visible_children = self.visible_childre(tiles);
+
+        let num_gaps = visible_children.len().saturating_sub(1);
         let gap_width = behavior.gap_width(style);
         let total_gap_width = gap_width * num_gaps as f32;
         let available_width = (rect.width() - total_gap_width).at_least(0.0);
 
-        let widths = self.shares.split(&self.children, available_width);
+        let widths = self.shares.split(&visible_children, available_width);
 
         let mut x = rect.min.x;
-        for (child, width) in self.children.iter().zip(widths) {
+        for (child, width) in visible_children.iter().zip(widths) {
             let child_rect = Rect::from_min_size(pos2(x, rect.min.y), vec2(width, rect.height()));
             tiles.layout_tile(style, behavior, child_rect, *child);
             x += width + gap_width;
@@ -175,15 +183,17 @@ impl Linear {
         behavior: &mut dyn Behavior<Pane>,
         rect: Rect,
     ) {
-        let num_gaps = self.children.len().saturating_sub(1);
+        let visible_children = self.visible_childre(tiles);
+
+        let num_gaps = visible_children.len().saturating_sub(1);
         let gap_height = behavior.gap_width(style);
         let total_gap_height = gap_height * num_gaps as f32;
         let available_height = (rect.height() - total_gap_height).at_least(0.0);
 
-        let heights = self.shares.split(&self.children, available_height);
+        let heights = self.shares.split(&visible_children, available_height);
 
         let mut y = rect.min.y;
-        for (child, height) in self.children.iter().zip(heights) {
+        for (child, height) in visible_children.iter().zip(heights) {
             let child_rect = Rect::from_min_size(pos2(rect.min.x, y), vec2(rect.width(), height));
             tiles.layout_tile(style, behavior, child_rect, *child);
             y += height + gap_height;
@@ -212,7 +222,9 @@ impl Linear {
         ui: &mut egui::Ui,
         parent_id: TileId,
     ) {
-        for &child in &self.children {
+        let visible_children = self.visible_childre(&tree.tiles);
+
+        for &child in &visible_children {
             tree.tile_ui(behavior, drop_context, ui, child);
             crate::cover_tile_if_dragged(tree, behavior, ui, child);
         }
@@ -228,7 +240,7 @@ impl Linear {
         // resizing:
 
         let parent_rect = tree.tiles.rect(parent_id);
-        for (i, (left, right)) in self.children.iter().copied().tuple_windows().enumerate() {
+        for (i, (left, right)) in visible_children.iter().copied().tuple_windows().enumerate() {
             let resize_id = egui::Id::new((parent_id, "resize", i));
 
             let left_rect = tree.tiles.rect(left);
@@ -248,7 +260,7 @@ impl Linear {
                 resize_state = resize_interaction(
                     behavior,
                     &mut self.shares,
-                    &self.children,
+                    &visible_children,
                     &response,
                     [left, right],
                     ui.painter().round_to_pixel(pointer.x) - x,
@@ -274,7 +286,9 @@ impl Linear {
         ui: &mut egui::Ui,
         parent_id: TileId,
     ) {
-        for &child in &self.children {
+        let visible_children = self.visible_childre(&tree.tiles);
+
+        for &child in &visible_children {
             tree.tile_ui(behavior, drop_context, ui, child);
             crate::cover_tile_if_dragged(tree, behavior, ui, child);
         }
@@ -290,7 +304,7 @@ impl Linear {
         // resizing:
 
         let parent_rect = tree.tiles.rect(parent_id);
-        for (i, (top, bottom)) in self.children.iter().copied().tuple_windows().enumerate() {
+        for (i, (top, bottom)) in visible_children.iter().copied().tuple_windows().enumerate() {
             let resize_id = egui::Id::new((parent_id, "resize", i));
 
             let top_rect = tree.tiles.rect(top);
@@ -310,7 +324,7 @@ impl Linear {
                 resize_state = resize_interaction(
                     behavior,
                     &mut self.shares,
-                    &self.children,
+                    &visible_children,
                     &response,
                     [top, bottom],
                     ui.painter().round_to_pixel(pointer.y) - y,
@@ -449,19 +463,21 @@ fn linear_drop_zones<Pane>(
         children,
         dragged_index,
         dir,
-        |tile_id| tree.tiles.rect(tile_id),
+        |tile_id| tree.tiles.try_rect(tile_id),
         add_drop_drect,
         after_rect,
     );
 }
 
 /// Register drop-zones for a linear container.
+///
+/// `get_rect`: return `None` for invisible tiles.
 pub(super) fn drop_zones(
     preview_thickness: f32,
     children: &[TileId],
     dragged_index: Option<usize>,
     dir: LinearDir,
-    get_rect: impl Fn(TileId) -> Rect,
+    get_rect: impl Fn(TileId) -> Option<Rect>,
     mut add_drop_drect: impl FnMut(Rect, usize),
     after_rect: impl Fn(Rect) -> Rect,
 ) {
@@ -490,7 +506,11 @@ pub(super) fn drop_zones(
     let mut insertion_index = 0; // skips over drag-source, if any, because it will be removed before its re-inserted
 
     for (i, &child) in children.iter().enumerate() {
-        let rect = get_rect(child);
+        let Some(rect) = get_rect(child) else {
+            // skip invisible child
+            insertion_index += 1;
+            continue;
+        };
 
         if Some(i) == dragged_index {
             // Suggest hole as a drop-target:

--- a/src/container/linear.rs
+++ b/src/container/linear.rs
@@ -104,7 +104,7 @@ impl Linear {
         }
     }
 
-    fn visible_childre<Pane>(&mut self, tiles: &Tiles<Pane>) -> Vec<TileId> {
+    fn visible_children<Pane>(&mut self, tiles: &Tiles<Pane>) -> Vec<TileId> {
         self.children
             .iter()
             .copied()
@@ -159,7 +159,7 @@ impl Linear {
         behavior: &mut dyn Behavior<Pane>,
         rect: Rect,
     ) {
-        let visible_children = self.visible_childre(tiles);
+        let visible_children = self.visible_children(tiles);
 
         let num_gaps = visible_children.len().saturating_sub(1);
         let gap_width = behavior.gap_width(style);
@@ -183,7 +183,7 @@ impl Linear {
         behavior: &mut dyn Behavior<Pane>,
         rect: Rect,
     ) {
-        let visible_children = self.visible_childre(tiles);
+        let visible_children = self.visible_children(tiles);
 
         let num_gaps = visible_children.len().saturating_sub(1);
         let gap_height = behavior.gap_width(style);
@@ -222,7 +222,7 @@ impl Linear {
         ui: &mut egui::Ui,
         parent_id: TileId,
     ) {
-        let visible_children = self.visible_childre(&tree.tiles);
+        let visible_children = self.visible_children(&tree.tiles);
 
         for &child in &visible_children {
             tree.tile_ui(behavior, drop_context, ui, child);
@@ -286,7 +286,7 @@ impl Linear {
         ui: &mut egui::Ui,
         parent_id: TileId,
     ) {
-        let visible_children = self.visible_childre(&tree.tiles);
+        let visible_children = self.visible_children(&tree.tiles);
 
         for &child in &visible_children {
             tree.tile_ui(behavior, drop_context, ui, child);

--- a/src/container/linear.rs
+++ b/src/container/linear.rs
@@ -353,6 +353,13 @@ impl Linear {
             }
         });
     }
+
+    /// Returns child index, if found.
+    pub(crate) fn remove_child(&mut self, needle: TileId) -> Option<usize> {
+        let index = self.children.iter().position(|&child| child == needle)?;
+        self.children.remove(index);
+        Some(index)
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/container/linear.rs
+++ b/src/container/linear.rs
@@ -510,30 +510,24 @@ pub(super) fn drop_zones(
     };
 
     let mut prev_rect: Option<Rect> = None;
-    let mut insertion_index = 0; // skips over drag-source, if any, because it will be removed before its re-inserted
 
     for (i, &child) in children.iter().enumerate() {
         let Some(rect) = get_rect(child) else {
             // skip invisible child
-            insertion_index += 1;
             continue;
         };
 
         if Some(i) == dragged_index {
             // Suggest hole as a drop-target:
             add_drop_drect(rect, i);
-        } else {
-            if let Some(prev_rect) = prev_rect {
-                if Some(i - 1) != dragged_index {
-                    // Suggest dropping between the rects:
-                    add_drop_drect(between_rects(prev_rect, rect), insertion_index);
-                }
-            } else {
-                // Suggest dropping before the first child:
-                add_drop_drect(before_rect(rect), 0);
+        } else if let Some(prev_rect) = prev_rect {
+            if Some(i - 1) != dragged_index {
+                // Suggest dropping between the rects:
+                add_drop_drect(between_rects(prev_rect, rect), i);
             }
-
-            insertion_index += 1;
+        } else {
+            // Suggest dropping before the first child:
+            add_drop_drect(before_rect(rect), 0);
         }
 
         prev_rect = Some(rect);
@@ -542,7 +536,7 @@ pub(super) fn drop_zones(
     if let Some(last_rect) = prev_rect {
         // Suggest dropping after the last child (unless that's the one being dragged):
         if dragged_index != Some(children.len() - 1) {
-            add_drop_drect(after_rect(last_rect), insertion_index + 1);
+            add_drop_drect(after_rect(last_rect), children.len());
         }
     }
 }

--- a/src/container/linear.rs
+++ b/src/container/linear.rs
@@ -19,7 +19,7 @@ pub struct Shares {
     ///
     /// For instance, the shares `[1, 2, 3]` means that the first child gets 1/6 of the space,
     /// the second gets 2/6 and the third gets 3/6.
-    shares: nohash_hasher::IntMap<TileId, f32>,
+    shares: ahash::HashMap<TileId, f32>,
 }
 
 impl Shares {
@@ -141,7 +141,7 @@ impl Linear {
         rect: Rect,
     ) {
         // GC:
-        let child_set: nohash_hasher::IntSet<TileId> = self.children.iter().copied().collect();
+        let child_set: ahash::HashSet<TileId> = self.children.iter().copied().collect();
         self.shares.retain(|id| child_set.contains(&id));
 
         match self.dir {

--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -147,6 +147,24 @@ impl Container {
         }
     }
 
+    /// Iterate through all children in order, and keep only those for which the closure returns `true`.
+    pub fn retain(&mut self, mut retain: impl FnMut(TileId) -> bool) {
+        match self {
+            Self::Tabs(tabs) => tabs.children.retain(|tile_id: &TileId| retain(*tile_id)),
+            Self::Linear(linear) => linear.children.retain(|tile_id: &TileId| retain(*tile_id)),
+            Self::Grid(grid) => grid.retain(retain),
+        }
+    }
+
+    /// Returns child index, if found.
+    pub fn remove_child(&mut self, child: TileId) -> Option<usize> {
+        match self {
+            Container::Tabs(tabs) => tabs.remove_child(child),
+            Container::Linear(linear) => linear.remove_child(child),
+            Container::Grid(grid) => grid.remove_child(child),
+        }
+    }
+
     pub fn kind(&self) -> ContainerKind {
         match self {
             Self::Tabs(_) => ContainerKind::Tabs,
@@ -173,15 +191,6 @@ impl Container {
             }
             ContainerKind::Grid => Self::Grid(Grid::new(self.children_vec())),
         };
-    }
-
-    /// Iterate through all children in order, and keep only those for which the closure returns `true`.
-    pub fn retain(&mut self, mut retain: impl FnMut(TileId) -> bool) {
-        match self {
-            Self::Tabs(tabs) => tabs.children.retain(|tile_id: &TileId| retain(*tile_id)),
-            Self::Linear(linear) => linear.children.retain(|tile_id: &TileId| retain(*tile_id)),
-            Self::Grid(grid) => grid.retain(retain),
-        }
     }
 
     pub(super) fn simplify_children(&mut self, simplify: impl FnMut(TileId) -> SimplifyAction) {

--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -146,7 +146,8 @@ impl Container {
         };
     }
 
-    pub(super) fn retain(&mut self, mut retain: impl FnMut(TileId) -> bool) {
+    /// Iterate through all children in order, and keep only those for which the closure returns `true`.
+    pub fn retain(&mut self, mut retain: impl FnMut(TileId) -> bool) {
         let retain = |tile_id: &TileId| retain(*tile_id);
         match self {
             Self::Tabs(tabs) => tabs.children.retain(retain),

--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -8,7 +8,7 @@ mod grid;
 mod linear;
 mod tabs;
 
-pub use grid::{Grid, GridLayout, GridLoc};
+pub use grid::{Grid, GridLayout};
 pub use linear::{Linear, LinearDir, Shares};
 pub use tabs::Tabs;
 

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -100,7 +100,7 @@ impl Tabs {
         let tab_bar_rect = rect.split_top_bottom_at_y(rect.top() + tab_bar_height).0;
         let mut ui = ui.child_ui(tab_bar_rect, *ui.layout());
 
-        let mut button_rects = nohash_hasher::IntMap::default();
+        let mut button_rects = ahash::HashMap::default();
         let mut dragged_index = None;
 
         ui.painter()

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -40,9 +40,19 @@ impl Tabs {
         behavior: &mut dyn Behavior<Pane>,
         rect: Rect,
     ) {
+        if let Some(active) = self.active {
+            if !tiles.is_visible(active) {
+                self.active = None;
+            }
+        }
+
         if !self.children.iter().any(|&child| self.is_active(child)) {
             // Make sure something is active:
-            self.active = self.children.first().copied();
+            self.active = self
+                .children
+                .iter()
+                .copied()
+                .find(|&child_id| tiles.is_visible(child_id));
         }
 
         let mut active_rect = rect;
@@ -121,6 +131,10 @@ impl Tabs {
                 }
 
                 for (i, &child_id) in self.children.iter().enumerate() {
+                    if !tree.is_visible(child_id) {
+                        continue;
+                    }
+
                     let is_being_dragged = is_being_dragged(ui.ctx(), child_id);
 
                     let selected = self.is_active(child_id);
@@ -171,7 +185,7 @@ impl Tabs {
             &self.children,
             dragged_index,
             super::LinearDir::Horizontal,
-            |tile_id| button_rects[&tile_id],
+            |tile_id| button_rects.get(&tile_id).copied(),
             |rect, i| {
                 drop_context.suggest_rect(
                     InsertionPoint::new(tile_id, ContainerInsertion::Tabs(i)),

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -211,4 +211,11 @@ impl Tabs {
             }
         });
     }
+
+    /// Returns child index, if found.
+    pub(crate) fn remove_child(&mut self, needle: TileId) -> Option<usize> {
+        let index = self.children.iter().position(|&child| child == needle)?;
+        self.children.remove(index);
+        Some(index)
+    }
 }

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -126,7 +126,7 @@ impl Tabs {
                         .on_hover_cursor(egui::CursorIcon::Grab)
                         .drag_started()
                     {
-                        ui.memory_mut(|mem| mem.set_dragged_id(tile_id.id()));
+                        ui.memory_mut(|mem| mem.set_dragged_id(tile_id.egui_id()));
                     }
                 }
 
@@ -138,7 +138,7 @@ impl Tabs {
                     let is_being_dragged = is_being_dragged(ui.ctx(), child_id);
 
                     let selected = self.is_active(child_id);
-                    let id = child_id.id();
+                    let id = child_id.egui_id();
 
                     let response =
                         behavior.tab_ui(&tree.tiles, ui, id, child_id, selected, is_being_dragged);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //!
 //! ## Invisible tiles
 //! Tiles can be made invisible with [`Tree::set_visible`] and [`Tiles::set_visible`].
-//! Invisible tiles stil retain their ordering in the container their in until
+//! Invisible tiles still retain their ordering in the container their in until
 //! they are made visible again.
 //!
 //! ## Shares

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,11 @@
 //! }
 //! ```
 //!
+//! ## Invisible tiles
+//! Tiles can be made invisible with [`Tree::set_visible`] and [`Tiles::set_visible`].
+//! Invisible tiles stil retain their ordering in the container their in until
+//! they are made visible again.
+//!
 //! ## Shares
 //! The relative sizes of linear layout (horizontal or vertical) and grid columns and rows are specified by _shares_.
 //! If the shares are `1,2,3` it means the first element gets `1/6` of the space, the second `2/6`, and the third `3/6`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ fn is_possible_drag(ctx: &egui::Context) -> bool {
 }
 
 fn is_being_dragged(ctx: &egui::Context, tile_id: TileId) -> bool {
-    ctx.memory(|mem| mem.is_being_dragged(tile_id.id())) && is_possible_drag(ctx)
+    ctx.memory(|mem| mem.is_being_dragged(tile_id.egui_id())) && is_possible_drag(ctx)
 }
 
 /// If this tile is currently being dragged, cover it with a semi-transparent overlay ([`Behavior::dragged_overlay_color`]).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@ enum ContainerInsertion {
     Tabs(usize),
     Horizontal(usize),
     Vertical(usize),
-    Grid(GridLoc),
+    Grid(usize),
 }
 
 /// Where in the tree to insert a tile.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,17 @@ enum ContainerInsertion {
     Grid(usize),
 }
 
+impl ContainerInsertion {
+    fn index(self) -> usize {
+        match self {
+            ContainerInsertion::Tabs(index)
+            | ContainerInsertion::Horizontal(index)
+            | ContainerInsertion::Vertical(index)
+            | ContainerInsertion::Grid(index) => index,
+        }
+    }
+}
+
 /// Where in the tree to insert a tile.
 #[derive(Clone, Copy, Debug)]
 struct InsertionPoint {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,7 @@ enum ContainerInsertion {
 }
 
 impl ContainerInsertion {
+    /// Where in the parent (in what order among its children).
     fn index(self) -> usize {
         match self {
             ContainerInsertion::Tabs(index)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ mod tiles;
 mod tree;
 
 pub use behavior::Behavior;
-pub use container::{Container, ContainerKind, Grid, GridLayout, GridLoc, Linear, LinearDir, Tabs};
+pub use container::{Container, ContainerKind, Grid, GridLayout, Linear, LinearDir, Tabs};
 pub use tile::{Tile, TileId};
 pub use tiles::Tiles;
 pub use tree::Tree;

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -10,8 +10,8 @@ impl TileId {
     }
 
     /// Corresponding [`egui::Id`], used for dragging.
-    pub fn id(&self) -> egui::Id {
-        egui::Id::new(self)
+    pub fn egui_id(&self) -> egui::Id {
+        egui::Id::new(("egui_tile", self))
     }
 }
 

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -4,14 +4,9 @@ use crate::{Container, ContainerKind};
 #[derive(Clone, Copy, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TileId(u64);
 
-/// [`TileId`] is a high-entropy random id, so this is fine:
-impl nohash_hasher::IsEnabled for TileId {}
-
 impl TileId {
-    /// Generate a new random [`TileId`].
-    pub fn random() -> Self {
-        use rand::Rng as _;
-        Self(rand::thread_rng().gen())
+    pub(crate) fn from_u64(n: u64) -> Self {
+        Self(n)
     }
 
     /// Corresponding [`egui::Id`], used for dragging.

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -384,7 +384,7 @@ impl<Pane> Tiles<Pane> {
 
             if kind == ContainerKind::Tabs {
                 if options.prune_empty_tabs && container.is_empty() {
-                    log::debug!("Simplify: removing empty tabs container");
+                    log::trace!("Simplify: removing empty tabs container");
                     return SimplifyAction::Remove;
                 }
 
@@ -398,7 +398,7 @@ impl<Pane> Tiles<Pane> {
                         {
                             // Keep it, even though we only one child
                         } else {
-                            log::debug!("Simplify: collapsing single-child tabs container");
+                            log::trace!("Simplify: collapsing single-child tabs container");
                             return SimplifyAction::Replace(only_child);
                         }
                     }
@@ -413,7 +413,7 @@ impl<Pane> Tiles<Pane> {
                             {
                                 if parent.dir == child.dir {
                                     // absorb the child
-                                    log::debug!(
+                                    log::trace!(
                                         "Simplify: absorbing nested linear container with {} children",
                                         child.children.len()
                                     );
@@ -444,12 +444,12 @@ impl<Pane> Tiles<Pane> {
                 }
 
                 if options.prune_empty_containers && container.is_empty() {
-                    log::debug!("Simplify: removing empty container tile");
+                    log::trace!("Simplify: removing empty container tile");
                     return SimplifyAction::Remove;
                 }
                 if options.prune_single_child_containers {
                     if let Some(only_child) = container.only_child() {
-                        log::debug!("Simplify: collapsing single-child container tile");
+                        log::trace!("Simplify: collapsing single-child container tile");
                         return SimplifyAction::Replace(only_child);
                     }
                 }

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -20,7 +20,7 @@ use super::{
 /// ```
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Tiles<Pane> {
-    pub tiles: nohash_hasher::IntMap<TileId, Tile<Pane>>,
+    tiles: nohash_hasher::IntMap<TileId, Tile<Pane>>,
 
     /// Tiles are visible by default, so we only store the invisible ones.
     invisible: nohash_hasher::IntSet<TileId>,
@@ -65,6 +65,26 @@ impl<Pane> Tiles<Pane> {
         self.tiles.get_mut(&tile_id)
     }
 
+    /// All tiles, in arbitrary order
+    pub fn iter(&self) -> impl Iterator<Item = (&TileId, &Tile<Pane>)> + '_ {
+        self.tiles.iter()
+    }
+
+    /// All [`TileId`]s, in arbitrary order
+    pub fn tile_ids(&self) -> impl Iterator<Item = TileId> + '_ {
+        self.tiles.keys().copied()
+    }
+
+    /// All [`Tile`]s in arbitrary order
+    pub fn tiles(&self) -> impl Iterator<Item = &Tile<Pane>> + '_ {
+        self.tiles.values()
+    }
+
+    /// All [`Tile`]s in arbitrary order
+    pub fn tiles_mut(&mut self) -> impl Iterator<Item = &mut Tile<Pane>> + '_ {
+        self.tiles.values_mut()
+    }
+
     /// Tiles are visible by default.
     ///
     /// Invisible tiles still retain their place in the tile hierarchy.
@@ -81,6 +101,14 @@ impl<Pane> Tiles<Pane> {
         } else {
             self.invisible.insert(tile_id);
         }
+    }
+
+    pub fn insert(&mut self, id: TileId, tile: Tile<Pane>) {
+        self.tiles.insert(id, tile);
+    }
+
+    pub fn remove(&mut self, id: TileId) -> Option<Tile<Pane>> {
+        self.tiles.remove(&id)
     }
 
     #[must_use]
@@ -141,7 +169,7 @@ impl<Pane> Tiles<Pane> {
         self.parent_of(tile_id).is_none()
     }
 
-    pub(super) fn insert(&mut self, insertion_point: InsertionPoint, child_id: TileId) {
+    pub(super) fn insert_at(&mut self, insertion_point: InsertionPoint, child_id: TileId) {
         let InsertionPoint {
             parent_id,
             insertion,

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -81,6 +81,11 @@ impl<Pane> Tiles<Pane> {
         self.tiles.iter()
     }
 
+    /// All tiles, in arbitrary order
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&TileId, &mut Tile<Pane>)> + '_ {
+        self.tiles.iter_mut()
+    }
+
     /// All [`TileId`]s, in arbitrary order
     pub fn tile_ids(&self) -> impl Iterator<Item = TileId> + '_ {
         self.tiles.keys().copied()

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -497,3 +497,19 @@ impl<Pane> Tiles<Pane> {
         activate
     }
 }
+
+impl<Pane: PartialEq> Tiles<Pane> {
+    /// Find the tile with the given pane.
+    pub fn find_pane(&self, needle: &Pane) -> Option<TileId> {
+        self.tiles
+            .iter()
+            .find(|(_, tile)| {
+                if let Tile::Pane(pane) = *tile {
+                    pane == needle
+                } else {
+                    false
+                }
+            })
+            .map(|(node_id, _)| *node_id)
+    }
+}

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -122,6 +122,26 @@ impl<Pane> Tiles<Pane> {
         self.tiles.remove(&id)
     }
 
+    /// Remove the given tile and all child tiles, recursively.
+    ///
+    /// All removed tiles are returned in unspecified order.
+    pub fn remove_recursively(&mut self, id: TileId) -> Vec<Tile<Pane>> {
+        let mut removed_tiles = vec![];
+        self.remove_recursively_impl(id, &mut removed_tiles);
+        removed_tiles
+    }
+
+    fn remove_recursively_impl(&mut self, id: TileId, removed_tiles: &mut Vec<Tile<Pane>>) {
+        if let Some(tile) = self.remove(id) {
+            if let Tile::Container(container) = &tile {
+                for &child_id in container.children() {
+                    self.remove_recursively_impl(child_id, removed_tiles);
+                }
+            }
+            removed_tiles.push(tile);
+        }
+    }
+
     #[must_use]
     pub fn insert_tile(&mut self, tile: Tile<Pane>) -> TileId {
         let id = TileId::random();

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -396,7 +396,7 @@ impl<Pane> Tiles<Pane> {
                             && child_is_pane
                             && parent_kind != Some(ContainerKind::Tabs)
                         {
-                            // Keep it, even though we only one child
+                            // Keep it, even though we only have one child
                         } else {
                             log::trace!("Simplify: collapsing single-child tabs container");
                             return SimplifyAction::Replace(only_child);

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -18,7 +18,7 @@ use super::{
 ///
 /// let tree = Tree::new(root, tiles);
 /// ```
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Tiles<Pane> {
     tiles: nohash_hasher::IntMap<TileId, Tile<Pane>>,
 
@@ -28,6 +28,17 @@ pub struct Tiles<Pane> {
     /// Filled in by the layout step at the start of each frame.
     #[serde(default, skip)]
     pub(super) rects: nohash_hasher::IntMap<TileId, Rect>,
+}
+
+impl<Pane: PartialEq> PartialEq for Tiles<Pane> {
+    fn eq(&self, other: &Tiles<Pane>) -> bool {
+        let Self {
+            tiles,
+            invisible,
+            rects: _, // ignore transient state
+        } = self;
+        tiles == &other.tiles && invisible == &other.invisible
+    }
 }
 
 impl<Pane> Default for Tiles<Pane> {

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -510,6 +510,6 @@ impl<Pane: PartialEq> Tiles<Pane> {
                     false
                 }
             })
-            .map(|(node_id, _)| *node_id)
+            .map(|(tile_id, _)| *tile_id)
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -400,7 +400,7 @@ impl<Pane> Tree<Pane> {
     ///
     /// Performs no simplifcations.
     ///
-    /// If found, the parent tile and the childs index is returned.
+    /// If found, the parent tile and the child's index is returned.
     pub(super) fn remove_tile_id_from_parent(
         &mut self,
         remove_me: TileId,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -131,7 +131,7 @@ impl<Pane> Tree<Pane> {
             .into_iter()
             .map(|pane| tiles.insert_pane(pane))
             .collect();
-        let root = tiles.insert_tile(Tile::Container(Container::new(kind, tile_ids)));
+        let root = tiles.insert_new(Tile::Container(Container::new(kind, tile_ids)));
         Self::new(root, tiles)
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -143,6 +143,20 @@ impl<Pane> Tree<Pane> {
         self.root == Some(tile)
     }
 
+    /// Tiles are visible by default.
+    ///
+    /// Invisible tiles still retain their place in the tile hierarchy.
+    pub fn is_visible(&self, tile_id: TileId) -> bool {
+        self.tiles.is_visible(tile_id)
+    }
+
+    /// Tiles are visible by default.
+    ///
+    /// Invisible tiles still retain their place in the tile hierarchy.
+    pub fn set_visible(&mut self, tile_id: TileId, visible: bool) {
+        self.tiles.set_visible(tile_id, visible);
+    }
+
     /// Show the tree in the given [`Ui`].
     ///
     /// The tree will use upp all the available space - nothing more, nothing less.
@@ -186,6 +200,9 @@ impl<Pane> Tree<Pane> {
         ui: &mut Ui,
         tile_id: TileId,
     ) {
+        if !self.is_visible(tile_id) {
+            return;
+        }
         // NOTE: important that we get the rect and tile in two steps,
         // otherwise we could loose the tile when there is no rect.
         let Some(rect) = self.tiles.try_rect(tile_id) else {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -209,7 +209,7 @@ impl<Pane> Tree<Pane> {
             log::warn!("Failed to find rect for tile {tile_id:?} during ui");
             return
         };
-        let Some(mut tile) = self.tiles.tiles.remove(&tile_id) else {
+        let Some(mut tile) = self.tiles.remove(tile_id) else {
             log::warn!("Failed to find tile {tile_id:?} during ui");
             return
         };
@@ -240,7 +240,7 @@ impl<Pane> Tree<Pane> {
             }
         };
 
-        self.tiles.tiles.insert(tile_id, tile);
+        self.tiles.insert(tile_id, tile);
         drop_context.enabled = drop_context_was_enabled;
     }
 
@@ -332,7 +332,7 @@ impl<Pane> Tree<Pane> {
             insertion_point.insertion
         );
         self.remove_tile_id_from_parent(moved_tile_id);
-        self.tiles.insert(insertion_point, moved_tile_id);
+        self.tiles.insert_at(insertion_point, moved_tile_id);
     }
 
     /// Find the currently dragged tile, if any.
@@ -342,7 +342,7 @@ impl<Pane> Tree<Pane> {
             return None;
         }
 
-        for &tile_id in self.tiles.tiles.keys() {
+        for tile_id in self.tiles.tile_ids() {
             if self.is_root(tile_id) {
                 continue; // not allowed to drag root
             }
@@ -368,7 +368,7 @@ impl<Pane> Tree<Pane> {
     ///
     /// Performs no simplifcations.
     pub(super) fn remove_tile_id_from_parent(&mut self, remove_me: TileId) {
-        for parent in self.tiles.tiles.values_mut() {
+        for parent in self.tiles.tiles_mut() {
             if let Tile::Container(container) = parent {
                 container.retain(|child| child != remove_me);
             }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -339,7 +339,7 @@ impl<Pane> Tree<Pane> {
                 log::trace!("Moving within the same parent: {source_index} -> {dest_index}");
                 // lets swap the two indices
 
-                let compensated_index = if source_index < dest_index {
+                let adjusted_index = if source_index < dest_index {
                     // We removed an earlier element, so we need to adjust the index:
                     dest_index.saturating_sub(1)
                 } else {
@@ -353,13 +353,14 @@ impl<Pane> Tree<Pane> {
                     Tile::Pane(_) => unreachable!(),
                     Tile::Container(container) => match container {
                         Container::Tabs(tabs) => {
-                            tabs.children.insert(compensated_index, moved_tile_id);
+                            tabs.children.insert(adjusted_index, moved_tile_id);
                             tabs.active = Some(moved_tile_id);
                         }
                         Container::Linear(linear) => {
-                            linear.children.insert(compensated_index, moved_tile_id);
+                            linear.children.insert(adjusted_index, moved_tile_id);
                         }
                         Container::Grid(grid) => {
+                            // the grid allow holes in its children list, so don't use `adjusted_index`
                             let dest = grid.replace_at(dest_index, moved_tile_id);
                             if let Some(dest) = dest {
                                 grid.insert_at(source_index, dest);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -232,7 +232,7 @@ impl<Pane> Tree<Pane> {
         match &mut tile {
             Tile::Pane(pane) => {
                 if behavior.pane_ui(&mut ui, tile_id, pane) == UiResponse::DragStarted {
-                    ui.memory_mut(|mem| mem.set_dragged_id(tile_id.id()));
+                    ui.memory_mut(|mem| mem.set_dragged_id(tile_id.egui_id()));
                 }
             }
             Tile::Container(container) => {
@@ -388,7 +388,7 @@ impl<Pane> Tree<Pane> {
                 continue; // not allowed to drag root
             }
 
-            let id = tile_id.id();
+            let id = tile_id.egui_id();
             let is_tile_being_dragged = ctx.memory(|mem| mem.is_being_dragged(id));
             if is_tile_being_dragged {
                 // Abort drags on escape:


### PR DESCRIPTION
This PR implements `is_visible/set_visible` for all tiles. Tiles are visible by default.

It also refactors the `Grid` container to avoid inadvertently re-arranging the order of its children.