### PR TITLE
🐍 Let `serde` be an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ ahash = { version = "0.8.1", default-features = false, features = [
 egui = { version = "0.23", default-features = false }
 itertools = "0.11"
 log = { version = "0.4", features = ["std"] }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"], optional = true }
 
 
 # For the example:
@@ -39,3 +39,7 @@ eframe = { version = "0.23", default-features = false, features = [
   "persistence",
 ] }
 env_logger = "0.10"
+
+[features]
+default = ["serde"]
+serde = ["dep:serde", "egui/serde"]

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -11,9 +11,11 @@ fn main() -> Result<(), eframe::Error> {
     eframe::run_native(
         "egui_tiles example",
         options,
-        Box::new(|cc| {
+        Box::new(|_cc| {
+            #[cfg_attr(not(feature = "serde"), allow(unused_mut))]
             let mut app = MyApp::default();
-            if let Some(storage) = cc.storage {
+            #[cfg(feature = "serde")]
+            if let Some(storage) = _cc.storage {
                 if let Some(state) = eframe::get_value(storage, eframe::APP_KEY) {
                     app = state;
                 }
@@ -247,8 +249,9 @@ impl eframe::App for MyApp {
         });
     }
 
-    fn save(&mut self, storage: &mut dyn eframe::Storage) {
-        eframe::set_value(storage, eframe::APP_KEY, &self);
+    fn save(&mut self, _storage: &mut dyn eframe::Storage) {
+        #[cfg(feature = "serde")]
+        eframe::set_value(_storage, eframe::APP_KEY, &self);
     }
 }
 

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), eframe::Error> {
     )
 }
 
-#[derive(serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Pane {
     nr: usize,
 }
@@ -156,14 +156,14 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
     }
 }
 
-#[derive(serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 struct MyApp {
     tree: egui_tiles::Tree<Pane>,
 
-    #[serde(skip)]
+    #[cfg_attr(feature = "serde", serde(skip))]
     behavior: TreeBehavior,
 
-    #[serde(skip)]
+    #[cfg_attr(feature = "serde", serde(skip))]
     last_tree_debug: String,
 }
 

--- a/src/container/grid.rs
+++ b/src/container/grid.rs
@@ -7,19 +7,8 @@ use crate::{
 };
 
 /// How to lay out the children of a grid.
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    serde::Serialize,
-    serde::Deserialize,
-)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum GridLayout {
     /// Place children in a grid, with a dynamic number of columns and rows.
     /// Resizing the window may change the number of columns and rows.
@@ -32,7 +21,8 @@ pub enum GridLayout {
 }
 
 /// A grid of tiles.
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Grid {
     /// The order of the children, row-major.
     ///
@@ -50,11 +40,11 @@ pub struct Grid {
     pub row_shares: Vec<f32>,
 
     /// ui point x ranges for each column, recomputed during layout
-    #[serde(skip)]
+    #[cfg_attr(feature = "serde", serde(skip))]
     col_ranges: Vec<Rangef>,
 
     /// ui point y ranges for each row, recomputed during layout
-    #[serde(skip)]
+    #[cfg_attr(feature = "serde", serde(skip))]
     row_ranges: Vec<Rangef>,
 }
 

--- a/src/container/linear.rs
+++ b/src/container/linear.rs
@@ -13,7 +13,8 @@ use crate::{
 /// Used for [`Linear`] containers (horizontal and vertical).
 ///
 /// Also contains the shares for currently invisible tiles.
-#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Shares {
     /// How large of a share each child has.
     ///
@@ -82,9 +83,8 @@ impl std::ops::IndexMut<TileId> for Shares {
 // ----------------------------------------------------------------------------
 
 /// The direction of a [`Linear`] container. Either horizontal or vertical.
-#[derive(
-    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum LinearDir {
     #[default]
     Horizontal,
@@ -92,7 +92,8 @@ pub enum LinearDir {
 }
 
 /// Horizontal or vertical container.
-#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Linear {
     pub children: Vec<TileId>,
     pub dir: LinearDir,

--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -17,7 +17,8 @@ pub use tabs::Tabs;
 /// The layout type of a [`Container`].
 ///
 /// This is used to describe a [`Container`], and to change it to a different layout type.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum ContainerKind {
     /// Each child in an individual tab.
     #[default]
@@ -40,7 +41,8 @@ impl ContainerKind {
 // ----------------------------------------------------------------------------
 
 /// A container of several [`super::Tile`]s.
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Container {
     Tabs(Tabs),
     Linear(Linear),

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -6,7 +6,8 @@ use crate::{
 };
 
 /// A container with tabs. Only one tab is open (active) at a time.
-#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Tabs {
     /// The tabs, in order.
     pub children: Vec<TileId>,

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,7 +1,8 @@
 use crate::{Container, ContainerKind};
 
 /// An identifier for a [`Tile`] in the tree, be it a [`Container`] or a pane.
-#[derive(Clone, Copy, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct TileId(u64);
 
 impl TileId {
@@ -24,7 +25,8 @@ impl std::fmt::Debug for TileId {
 // ----------------------------------------------------------------------------
 
 /// A tile in the tree. Either a pane (leaf) or a [`Container`] of more tiles.
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Tile<Pane> {
     /// A leaf. This is where the user puts their UI, using the [`crate::Behavior`] trait.
     Pane(Pane),

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -18,7 +18,8 @@ use super::{
 ///
 /// let tree = Tree::new(root, tiles);
 /// ```
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Tiles<Pane> {
     next_tile_id: u64,
 
@@ -28,7 +29,7 @@ pub struct Tiles<Pane> {
     invisible: ahash::HashSet<TileId>,
 
     /// Filled in by the layout step at the start of each frame.
-    #[serde(default, skip)]
+    #[cfg_attr(feature = "serde", serde(default, skip))]
     pub(super) rects: ahash::HashMap<TileId, Rect>,
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -25,7 +25,8 @@ use super::{
 ///
 /// let tree = Tree::new(root, tiles);
 /// ```
-#[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Tree<Pane> {
     /// None = empty tree
     pub root: Option<TileId>,


### PR DESCRIPTION
This PR marks `serde` as an option dependency and only derives the various `Serialize` and `Deserialize` traits when this feature is enabled. 

Regardless of not forcing the user to have the `serde` dependency, having the `serde` feature of `egui` (optionally) enabled is a requirement for #12.