### PR TITLE
Moved dragged widget UI to `Behaviour`

### DIFF
--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -89,6 +89,17 @@ pub trait Behavior<Pane> {
         response
     }
 
+    /// Show the ui for the tab being dragged.
+    fn drag_ui(&mut self, tiles: &Tiles<Pane>, ui: &mut Ui, tile_id: TileId) {
+        let mut frame = egui::Frame::popup(ui.style());
+        frame.fill = frame.fill.gamma_multiply(0.5); // Make see-through
+        frame.show(ui, |ui| {
+            // TODO(emilk): preview contents?
+            let text = self.tab_title_for_tile(tiles, tile_id);
+            ui.label(text);
+        });
+    }
+
     /// Called by the default implementation of [`Self::tab_ui`] for each added button
     fn on_tab_button(
         &mut self,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -277,7 +277,7 @@ impl<Pane> Tree<Pane> {
             .current_pos(mouse_pos)
             .interactable(false)
             .show(ui.ctx(), |ui| {
-                behavior.drag_ui(&self.tiles, ui, dragged_tile_id)
+                behavior.drag_ui(&self.tiles, ui, dragged_tile_id);
             });
 
         if let Some(preview_rect) = drop_context.preview_rect {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -277,13 +277,7 @@ impl<Pane> Tree<Pane> {
             .current_pos(mouse_pos)
             .interactable(false)
             .show(ui.ctx(), |ui| {
-                let mut frame = egui::Frame::popup(ui.style());
-                frame.fill = frame.fill.gamma_multiply(0.5); // Make see-through
-                frame.show(ui, |ui| {
-                    // TODO(emilk): preview contents?
-                    let text = behavior.tab_title_for_tile(&self.tiles, dragged_tile_id);
-                    ui.label(text);
-                });
+                behavior.drag_ui(&self.tiles, ui, dragged_tile_id)
             });
 
         if let Some(preview_rect) = drop_context.preview_rect {


### PR DESCRIPTION
.It's currently impossible to customise the look of the dragged widget. This PR moves the relevant code to a new function in `Behavior`, enabling customisation in client code.