### PR TITLE
POC: Undocking of tiles into their own viewports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,7 @@ env_logger = "0.10"
 [features]
 default = ["serde"]
 serde = ["dep:serde", "egui/serde"]
+
+[patch.crates-io]
+eframe = { git = "https://github.com/emilk/egui.git", rev = "beb4714e406adfaad54eb7365785d9a4ba90f789" } # egui master 2023-11-17
+egui = { git = "https://github.com/emilk/egui.git", rev = "beb4714e406adfaad54eb7365785d9a4ba90f789" }   # egui master 2023-11-17

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -223,7 +223,11 @@ impl eframe::App for MyApp {
             ui.separator();
 
             if let Some(root) = self.tree.root() {
-                tree_ui(ui, &mut self.behavior, &mut self.tree.tiles, root);
+                egui::ScrollArea::vertical()
+                    .auto_shrink(false)
+                    .show(ui, |ui| {
+                        tree_ui(ui, &mut self.behavior, &mut self.tree.tiles, root);
+                    });
             }
 
             if let Some(parent) = self.behavior.add_child_to.take() {

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -308,19 +308,18 @@ impl<Pane> Tiles<Pane> {
     /// Will also call [`Behavior::retain_pane`] to check if a users wants to remove a pane.
     ///
     /// Finally free up any tiles that are no longer reachable from the root.
-    pub(super) fn gc_root(&mut self, behavior: &mut dyn Behavior<Pane>, root_id: Option<TileId>) {
+    pub(super) fn gc_roots(&mut self, behavior: &mut dyn Behavior<Pane>, roots: &[TileId]) {
         let mut visited = Default::default();
 
-        if let Some(root_id) = root_id {
+        for &root_id in roots {
             // We ignore the returned root action, because we will never remove the root.
             let _root_action = self.gc_tile_id(behavior, &mut visited, root_id);
         }
 
         if visited.len() < self.tiles.len() {
-            // This should only happen if the user set up the tree in a bad state,
-            // or if it was restored from a bad state via serde.
-            // …or if there is a bug somewhere 😜
-            log::warn!(
+            // This can happen if a user coses a whole tree of viewports,
+            // e.g. when closing a viewport tile.
+            log::debug!(
                 "GC collecting tiles: {:?}",
                 self.tiles
                     .keys()


### PR DESCRIPTION
* experimentation for https://github.com/rerun-io/egui_tiles/issues/30

Supports:
* [x] Undocking a tile by dragging it out of the root viewport
* [ ] Drag-dropping within a child viewport
* [ ] Drag-dropping between viewports
* [ ] Re-docking