### PR TITLE
Add `SimplificationOptions::off()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,30 @@ pub struct SimplificationOptions {
     pub join_nested_linear_containers: bool,
 }
 
+impl SimplificationOptions {
+    /// Make a [`SimplificationOptions`] with all simplifications turned off.
+    ///
+    /// This makes it easy to run a single simplification type on a tree:
+    /// ```
+    /// # use egui_tiles::*;
+    /// # let mut tree: Tree<()> = Tree::empty("tree");
+    /// tree.simplify(&SimplificationOptions {
+    ///     prune_empty_tabs: true,
+    ///     ..SimplificationOptions::off()
+    /// });
+    ///
+    pub fn off() -> Self {
+        Self {
+            prune_empty_tabs: false,
+            prune_empty_containers: false,
+            prune_single_child_tabs: false,
+            prune_single_child_containers: false,
+            all_panes_must_have_tabs: false,
+            join_nested_linear_containers: false,
+        }
+    }
+}
+
 impl Default for SimplificationOptions {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
This enables easily running `simplify()` on a single category:

```rust
tree.simplify(&SimplificationOptions {
    prune_empty_tabs: true,
    ..SimplificationOptions::off()
});
```