### PR TITLE
Expose the internal u64 part of TileId

### DIFF
--- a/src/tile.rs
+++ b/src/tile.rs
@@ -8,6 +8,7 @@ use crate::{Container, ContainerKind};
 pub struct TileId(pub u64);
 
 impl TileId {
+    #[inline]
     pub fn from_u64(n: u64) -> Self {
         Self(n)
     }

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -5,10 +5,10 @@ use crate::{Container, ContainerKind};
 /// This id is unique within the tree, but not across trees.
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct TileId(u64);
+pub struct TileId(pub u64);
 
 impl TileId {
-    pub(crate) fn from_u64(n: u64) -> Self {
+    pub fn from_u64(n: u64) -> Self {
         Self(n)
     }
 

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -167,7 +167,7 @@ impl<Pane> Tiles<Pane> {
         }
     }
 
-    fn next_free_id(&mut self) -> TileId {
+    pub fn next_free_id(&mut self) -> TileId {
         let mut id = TileId::from_u64(self.next_tile_id);
 
         // Make sure it doesn't collide with an existing id

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -167,10 +167,24 @@ impl<Pane> Tiles<Pane> {
         }
     }
 
+    fn next_free_id(&mut self) -> TileId {
+        let mut id = TileId::from_u64(self.next_tile_id);
+
+        // Make sure it doesn't collide with an existing id
+        while self.tiles.get(&id).is_some() {
+            self.next_tile_id += 1;
+            id = TileId::from_u64(self.next_tile_id);
+        }
+
+        // Final increment the next_id
+        self.next_tile_id += 1;
+
+        id
+    }
+
     #[must_use]
     pub fn insert_new(&mut self, tile: Tile<Pane>) -> TileId {
-        let id = TileId::from_u64(self.next_tile_id);
-        self.next_tile_id += 1;
+        let id = self.next_free_id();
         self.tiles.insert(id, tile);
         id
     }


### PR DESCRIPTION
This makes it significantly easier to map to and from other externally managed ids.

Also, uncovered and resolved a related issue to inserting arbitrary ids into a new tree by checking for collisions on insert.