### PR TITLE
Fix simplification errors that result in warnings after removing panes

### DIFF
--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -151,6 +151,13 @@ impl<Pane> Tiles<Pane> {
     ///
     /// All removed tiles are returned in unspecified order.
     pub fn remove_recursively(&mut self, id: TileId) -> Vec<Tile<Pane>> {
+        // Remove the top tile_id from its parent
+        for tile in self.tiles.values_mut() {
+            if let Tile::Container(container) = tile {
+                container.remove_child(id);
+            }
+        }
+
         let mut removed_tiles = vec![];
         self.remove_recursively_impl(id, &mut removed_tiles);
         removed_tiles

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -143,35 +143,13 @@ impl<Pane> Tiles<Pane> {
         self.tiles.insert(id, tile);
     }
 
+    /// Remove the tile with the given id from the tiles container.
+    ///
+    /// Note that this does not actually remove the tile from the tree and may
+    /// leave dangling references. If you want to permanently remove the tile
+    /// consider calling [`crate::Tree::remove_recursively`].
     pub fn remove(&mut self, id: TileId) -> Option<Tile<Pane>> {
         self.tiles.remove(&id)
-    }
-
-    /// Remove the given tile and all child tiles, recursively.
-    ///
-    /// All removed tiles are returned in unspecified order.
-    pub fn remove_recursively(&mut self, id: TileId) -> Vec<Tile<Pane>> {
-        // Remove the top tile_id from its parent
-        for tile in self.tiles.values_mut() {
-            if let Tile::Container(container) = tile {
-                container.remove_child(id);
-            }
-        }
-
-        let mut removed_tiles = vec![];
-        self.remove_recursively_impl(id, &mut removed_tiles);
-        removed_tiles
-    }
-
-    fn remove_recursively_impl(&mut self, id: TileId, removed_tiles: &mut Vec<Tile<Pane>>) {
-        if let Some(tile) = self.remove(id) {
-            if let Tile::Container(container) = &tile {
-                for &child_id in container.children() {
-                    self.remove_recursively_impl(child_id, removed_tiles);
-                }
-            }
-            removed_tiles.push(tile);
-        }
     }
 
     pub fn next_free_id(&mut self) -> TileId {
@@ -408,9 +386,9 @@ impl<Pane> Tiles<Pane> {
     /// and/or merging single-child containers into their parent.
     ///
     /// Drag-dropping tiles can often leave containers empty, or with only a single child.
-    /// This is often undersired, so this function can be used to clean up the tree.
+    /// This is often undesired, so this function can be used to clean up the tree.
     ///
-    /// What simplifcations are allowed is controlled by the [`SimplificationOptions`].
+    /// What simplifications are allowed is controlled by the [`SimplificationOptions`].
     pub(super) fn simplify(
         &mut self,
         options: &SimplificationOptions,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -156,6 +156,34 @@ impl<Pane> Tree<Pane> {
         Self::new(id, root, tiles)
     }
 
+    /// Remove the given tile and all child tiles, recursively.
+    ///
+    /// This also removes the tile id from the parent's list of children.
+    ///
+    /// All removed tiles are returned in unspecified order.
+    pub fn remove_recursively(&mut self, id: TileId) -> Vec<Tile<Pane>> {
+        // Remove the top-most tile_id from its parent
+        self.remove_tile_id_from_parent(id);
+
+        let mut removed_tiles = vec![];
+        self.remove_recursively_impl(id, &mut removed_tiles);
+        removed_tiles
+    }
+
+    fn remove_recursively_impl(&mut self, id: TileId, removed_tiles: &mut Vec<Tile<Pane>>) {
+        // We can safely use the raw `tiles.remove` API here because either the parent was cleaned
+        // up explicitly from `remove_recursively` or the parent is also being removed so there's
+        // no reason to clean it up.
+        if let Some(tile) = self.tiles.remove(id) {
+            if let Tile::Container(container) = &tile {
+                for &child_id in container.children() {
+                    self.remove_recursively_impl(child_id, removed_tiles);
+                }
+            }
+            removed_tiles.push(tile);
+        }
+    }
+
     /// The globally unique id used by this `Tree`.
     #[inline]
     pub fn id(&self) -> egui::Id {
@@ -365,6 +393,15 @@ impl<Pane> Tree<Pane> {
                     self.tiles.make_all_panes_children_of_tabs(false, tile_id);
                 }
             }
+        }
+    }
+
+    /// Simplify all of the children of the given tile.
+    pub fn simplify_children_of_tile(&mut self, tile_id: TileId, options: &SimplificationOptions) {
+        if let Some(Tile::Container(mut container)) = self.tiles.remove(tile_id) {
+            let kind = container.kind();
+            container.simplify_children(|child| self.tiles.simplify(options, child, Some(kind)));
+            self.tiles.insert(tile_id, Tile::Container(container));
         }
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -350,24 +350,21 @@ impl<Pane> Tree<Pane> {
     /// This is also called at the start of [`Self::ui`].
     pub fn simplify(&mut self, options: &SimplificationOptions) {
         if let Some(root) = self.root {
-            self.simplify_tile(root, options);
-        }
-    }
-
-    /// Simplify and normalize a tile and all its children using the given options.
-    pub fn simplify_tile(&mut self, tile_id: TileId, options: &SimplificationOptions) {
-        match self.tiles.simplify(options, tile_id, None) {
-            SimplifyAction::Keep => {}
-            SimplifyAction::Remove => {
-                self.root = None;
+            match self.tiles.simplify(options, root, None) {
+                SimplifyAction::Keep => {}
+                SimplifyAction::Remove => {
+                    self.root = None;
+                }
+                SimplifyAction::Replace(new_root) => {
+                    self.root = Some(new_root);
+                }
             }
-            SimplifyAction::Replace(new_root) => {
-                self.root = Some(new_root);
-            }
-        }
 
-        if options.all_panes_must_have_tabs {
-            self.tiles.make_all_panes_children_of_tabs(false, tile_id);
+            if options.all_panes_must_have_tabs {
+                if let Some(tile_id) = self.root {
+                    self.tiles.make_all_panes_children_of_tabs(false, tile_id);
+                }
+            }
         }
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -396,7 +396,7 @@ impl<Pane> Tree<Pane> {
         }
     }
 
-    /// Simplify all of the children of the given tile.
+    /// Simplify all of the children of the given container tile recursively.
     pub fn simplify_children_of_tile(&mut self, tile_id: TileId, options: &SimplificationOptions) {
         if let Some(Tile::Container(mut container)) = self.tiles.remove(tile_id) {
             let kind = container.kind();


### PR DESCRIPTION
- When removing a tile, it needs to be removed from its parents list of children
- When simplifying a tree that collapses the root, use the correct tile_id post-simplification.

This results in a few API changes:
 - `remove_recursively` is moved from the `Tiles` container to the `Tree` container.
 - `simplify_tile_id` is replaced by `simplify_children_of_tile` to avoid ambiguity where simplification would cause that tile to be simplified out of existence.