### PR TITLE
Make sure there is always an active tab

### DIFF
--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -16,7 +16,8 @@ pub enum EditAction {
     /// A tile was dropped and its position changed accordingly.
     TileDropped,
 
-    /// A tab was selected by a click or by hovering a dragged tile over it.
+    /// A tab was selected by a click, or by hovering a dragged tile over it,
+    /// or there was no active tab and egui picked an arbitrary one.
     TabSelected,
 }
 

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -155,6 +155,23 @@ impl Tabs {
         behavior: &mut dyn Behavior<Pane>,
         rect: Rect,
     ) {
+        let prev_active = self.active;
+        self.ensure_active(tiles);
+        if prev_active != self.active {
+            behavior.on_edit(EditAction::TabSelected);
+        }
+
+        let mut active_rect = rect;
+        active_rect.min.y += behavior.tab_bar_height(style);
+
+        if let Some(active) = self.active {
+            // Only lay out the active tab (saves CPU):
+            tiles.layout_tile(style, behavior, active_rect, active);
+        }
+    }
+
+    /// Make sure we have an active tab (or no visible tabs).
+    pub fn ensure_active<Pane>(&mut self, tiles: &Tiles<Pane>) {
         if let Some(active) = self.active {
             if !tiles.is_visible(active) {
                 self.active = None;
@@ -168,14 +185,6 @@ impl Tabs {
                 .iter()
                 .copied()
                 .find(|&child_id| tiles.is_visible(child_id));
-        }
-
-        let mut active_rect = rect;
-        active_rect.min.y += behavior.tab_bar_height(style);
-
-        if let Some(active) = self.active {
-            // Only lay out the active tab (saves CPU):
-            tiles.layout_tile(style, behavior, active_rect, active);
         }
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -582,14 +582,28 @@ impl<Pane> Tree<Pane> {
         &mut self,
         remove_me: TileId,
     ) -> Option<(TileId, usize)> {
+        let mut result = None;
+
         for (parent_id, parent) in self.tiles.iter_mut() {
             if let Tile::Container(container) = parent {
                 if let Some(child_index) = container.remove_child(remove_me) {
-                    return Some((*parent_id, child_index));
+                    result = Some((*parent_id, child_index));
                 }
             }
         }
-        None
+
+        // Make sure that if we drag away the active some tabs,
+        // that the tab container gets assigned another active tab.
+        if let Some((parent_id, _)) = result {
+            if let Some(mut tile) = self.tiles.remove(parent_id) {
+                if let Tile::Container(Container::Tabs(tabs)) = &mut tile {
+                    tabs.ensure_active(&self.tiles);
+                }
+                self.tiles.insert(parent_id, tile);
+            }
+        }
+
+        result
     }
 }
 


### PR DESCRIPTION
When dragging away an active tab, select a new active tab _right away_. This ensures things like `active_tiles` works right away, and don't need waiting for the next call to `.ui()`.

Still, if there is no active tab on `ui`, call `behavior.on_edit` to inform the user that there has been a new selection.