### PR TITLE
Fix `move_tile_to_container` behavior for grid-to-same-grid moves with reflow enabled

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -523,15 +523,14 @@ impl<Pane> Tree<Pane> {
                                 linear.children.insert(insertion_index, moved_tile_id);
                             }
                             Container::Grid(grid) => {
-                                let index = if reflow_grid {
-                                    adjusted_index
+                                if reflow_grid {
+                                    self.tiles.insert_at(insertion_point, moved_tile_id);
                                 } else {
-                                    dest_index
+                                    let dest_tile = grid.replace_at(dest_index, moved_tile_id);
+                                    if let Some(dest) = dest_tile {
+                                        grid.insert_at(source_index, dest);
+                                    }
                                 };
-                                let dest_tile = grid.replace_at(index, moved_tile_id);
-                                if let Some(dest) = dest_tile {
-                                    grid.insert_at(source_index, dest);
-                                }
                             }
                         }
                         return; // done


### PR DESCRIPTION
- Fixes #52
- Required for https://github.com/rerun-io/rerun/issues/5081