### PR TITLE
Re-export `Shares`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ mod tiles;
 mod tree;
 
 pub use behavior::{Behavior, EditAction};
-pub use container::{Container, ContainerKind, Grid, GridLayout, Linear, LinearDir, Tabs};
+pub use container::{Container, ContainerKind, Grid, GridLayout, Linear, LinearDir, Shares, Tabs};
 pub use tile::{Tile, TileId};
 pub use tiles::Tiles;
 pub use tree::Tree;


### PR DESCRIPTION
Re-export the `Shares` type, making it visible to users of the library.

This makes working with `Shares` a little bit nicer, as we could only create a new `Shares` indirectly with `Linear::default()`.