### PR TITLE
Fix: make sure `Tree::ui` allocates the space it uses in parent `Ui`

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -256,16 +256,18 @@ impl<Pane> Tree<Pane> {
             preview_rect: None,
         };
 
+        let rect = ui.available_rect_before_wrap();
+
         if let Some(root) = self.root {
             self.tiles
-                .layout_tile(ui.style(), behavior, ui.available_rect_before_wrap(), root);
+                .layout_tile(ui.style(), behavior, rect, root);
 
             self.tile_ui(behavior, &mut drop_context, ui, root);
         }
 
         self.preview_dragged_tile(behavior, &drop_context, ui);
         // resizes the window to fit the ui.
-        ui.allocate_space(ui.available_size());
+        ui.advance_cursor_after_rect(rect);
     }
 
     pub(super) fn tile_ui(

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -259,8 +259,7 @@ impl<Pane> Tree<Pane> {
         let rect = ui.available_rect_before_wrap();
 
         if let Some(root) = self.root {
-            self.tiles
-                .layout_tile(ui.style(), behavior, rect, root);
+            self.tiles.layout_tile(ui.style(), behavior, rect, root);
 
             self.tile_ui(behavior, &mut drop_context, ui, root);
         }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -266,7 +266,8 @@ impl<Pane> Tree<Pane> {
         }
 
         self.preview_dragged_tile(behavior, &drop_context, ui);
-        // resizes the window to fit the ui.
+
+        // Allocate the used space in the parent Ui:
         ui.advance_cursor_after_rect(rect);
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -264,6 +264,8 @@ impl<Pane> Tree<Pane> {
         }
 
         self.preview_dragged_tile(behavior, &drop_context, ui);
+        // resizes the window to fit the ui.
+        ui.allocate_space(ui.available_size());
     }
 
     pub(super) fn tile_ui(


### PR DESCRIPTION
I discovered in
https://github.com/rerun-io/egui_tiles/issues/69

that the window of a tree ui does not fully fit inside the window by default. This pr fixes that issue by adding
```rust
ui.allocate_space(ui.available_size());
```
to the end of `tree.ui()`.

