### PR TITLE
PR to resolve issue 69

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -264,6 +264,7 @@ impl<Pane> Tree<Pane> {
         }
 
         self.preview_dragged_tile(behavior, &drop_context, ui);
+        ui.allocate_space(ui.available_size());
     }
 
     pub(super) fn tile_ui(


### PR DESCRIPTION
resolves #69 - tree.ui sprawls outside of Window when not using CentralPanel.