### PR TITLE
Fix container resize drag for touchscreens.

### DIFF
--- a/src/container/grid.rs
+++ b/src/container/grid.rs
@@ -284,15 +284,17 @@ impl Grid {
             let x = egui::lerp(left.max..=right.min, 0.5);
 
             let mut resize_state = ResizeState::Idle;
-            if let Some(pointer) = ui.ctx().pointer_latest_pos() {
-                let line_rect = Rect::from_center_size(
-                    pos2(x, parent_rect.center().y),
-                    vec2(
-                        2.0 * ui.style().interaction.resize_grab_radius_side,
-                        parent_rect.height(),
-                    ),
-                );
-                let response = ui.interact(line_rect, resize_id, egui::Sense::click_and_drag());
+            let line_rect = Rect::from_center_size(
+                pos2(x, parent_rect.center().y),
+                vec2(
+                    2.0 * ui.style().interaction.resize_grab_radius_side,
+                    parent_rect.height(),
+                ),
+            );
+            let response = ui.interact(line_rect, resize_id, egui::Sense::click_and_drag());
+            // NOTE: Check for interaction with line_rect BEFORE entering the 'IF block' below,
+            // otherwise we miss the start of a drag event in certain cases (e.g. touchscreens).
+            if let Some(pointer) = ui.ctx().pointer_interact_pos() {
                 resize_state = resize_interaction(
                     behavior,
                     &self.col_ranges,
@@ -326,15 +328,17 @@ impl Grid {
             let y = egui::lerp(top.max..=bottom.min, 0.5);
 
             let mut resize_state = ResizeState::Idle;
-            if let Some(pointer) = ui.ctx().pointer_latest_pos() {
-                let line_rect = Rect::from_center_size(
-                    pos2(parent_rect.center().x, y),
-                    vec2(
-                        parent_rect.width(),
-                        2.0 * ui.style().interaction.resize_grab_radius_side,
-                    ),
-                );
-                let response = ui.interact(line_rect, resize_id, egui::Sense::click_and_drag());
+            let line_rect = Rect::from_center_size(
+                pos2(parent_rect.center().x, y),
+                vec2(
+                    parent_rect.width(),
+                    2.0 * ui.style().interaction.resize_grab_radius_side,
+                ),
+            );
+            let response = ui.interact(line_rect, resize_id, egui::Sense::click_and_drag());
+            // NOTE: Check for interaction with line_rect BEFORE entering the 'IF block' below,
+            // otherwise we miss the start of a drag event in certain cases (e.g. touchscreens).
+            if let Some(pointer) = ui.ctx().pointer_interact_pos() {
                 resize_state = resize_interaction(
                     behavior,
                     &self.row_ranges,

--- a/src/container/linear.rs
+++ b/src/container/linear.rs
@@ -263,15 +263,17 @@ impl Linear {
             let x = egui::lerp(left_rect.right()..=right_rect.left(), 0.5);
 
             let mut resize_state = ResizeState::Idle;
-            if let Some(pointer) = ui.ctx().pointer_latest_pos() {
-                let line_rect = Rect::from_center_size(
-                    pos2(x, parent_rect.center().y),
-                    vec2(
-                        2.0 * ui.style().interaction.resize_grab_radius_side,
-                        parent_rect.height(),
-                    ),
-                );
-                let response = ui.interact(line_rect, resize_id, egui::Sense::click_and_drag());
+            let line_rect = Rect::from_center_size(
+                pos2(x, parent_rect.center().y),
+                vec2(
+                    2.0 * ui.style().interaction.resize_grab_radius_side,
+                    parent_rect.height(),
+                ),
+            );
+            let response = ui.interact(line_rect, resize_id, egui::Sense::click_and_drag());
+            // NOTE: Check for interaction with line_rect BEFORE entering the 'IF block' below,
+            // otherwise we miss the start of a drag event in certain cases (e.g. touchscreens).
+            if let Some(pointer) = ui.ctx().pointer_interact_pos() {
                 resize_state = resize_interaction(
                     behavior,
                     &mut self.shares,
@@ -327,15 +329,17 @@ impl Linear {
             let y = egui::lerp(top_rect.bottom()..=bottom_rect.top(), 0.5);
 
             let mut resize_state = ResizeState::Idle;
-            if let Some(pointer) = ui.ctx().pointer_latest_pos() {
-                let line_rect = Rect::from_center_size(
-                    pos2(parent_rect.center().x, y),
-                    vec2(
-                        parent_rect.width(),
-                        2.0 * ui.style().interaction.resize_grab_radius_side,
-                    ),
-                );
-                let response = ui.interact(line_rect, resize_id, egui::Sense::click_and_drag());
+            let line_rect = Rect::from_center_size(
+                pos2(parent_rect.center().x, y),
+                vec2(
+                    parent_rect.width(),
+                    2.0 * ui.style().interaction.resize_grab_radius_side,
+                ),
+            );
+            let response = ui.interact(line_rect, resize_id, egui::Sense::click_and_drag());
+            // NOTE: Check for interaction with line_rect BEFORE entering the 'IF block' below,
+            // otherwise we miss the start of a drag event in certain cases (e.g. touchscreens).
+            if let Some(pointer) = ui.ctx().pointer_interact_pos() {
                 resize_state = resize_interaction(
                     behavior,
                     &mut self.shares,


### PR DESCRIPTION
Container resize drags do not work on touchscreens because ui.interact(...) is called AFTER the drag event started. This PR moves the ui.interact(...) call for the "resize drag handle" out of the current IF block so that the start of the drag event can be registered properly.

This was mostly not a problem for mouse-based interaction because the IF condition on 'latest_pos()' returns true most of the time as long as the mouse pointer is hovering over the screen input area. This is of course not the case with touchscreens, hence additionally 'latest_pos()' was replaced by 'interact_pos()'.

Fix tested on:
wasm + touchscreen
wasm + mouse
native + mouse