### PR TITLE
Use better names for some variables

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -328,8 +328,8 @@ fn tree_ui(
             egui::ComboBox::from_label("Kind")
                 .selected_text(format!("{kind:?}"))
                 .show_ui(ui, |ui| {
-                    for typ in egui_tiles::ContainerKind::ALL {
-                        ui.selectable_value(&mut kind, typ, format!("{typ:?}"))
+                    for alternative in egui_tiles::ContainerKind::ALL {
+                        ui.selectable_value(&mut kind, alternative, format!("{alternative:?}"))
                             .clicked();
                     }
                 });

--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -71,8 +71,8 @@ impl From<Grid> for Container {
 }
 
 impl Container {
-    pub fn new(typ: ContainerKind, children: Vec<TileId>) -> Self {
-        match typ {
+    pub fn new(kind: ContainerKind, children: Vec<TileId>) -> Self {
+        match kind {
             ContainerKind::Tabs => Self::new_tabs(children),
             ContainerKind::Horizontal => Self::new_horizontal(children),
             ContainerKind::Vertical => Self::new_vertical(children),


### PR DESCRIPTION
The old names tripped up `typos`, and were bad anyways