### PR TITLE
Use the next active tab when iterating active tiles

### DIFF
--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -125,15 +125,15 @@ impl Container {
     ///
     /// For tabs, this is just the active tab.
     /// For other containers, it is all children.
-    pub fn active_children(&self) -> impl Iterator<Item = &TileId> {
+    pub fn active_children<Pane>(&self, tiles: &Tiles<Pane>) -> impl Iterator<Item = TileId> {
         match self {
-            Self::Tabs(tabs) => {
-                itertools::Either::Left(itertools::Either::Left(tabs.active.iter()))
-            }
+            Self::Tabs(tabs) => itertools::Either::Left(itertools::Either::Left(
+                tabs.next_active(tiles).into_iter(),
+            )),
             Self::Linear(linear) => {
-                itertools::Either::Left(itertools::Either::Right(linear.children.iter()))
+                itertools::Either::Left(itertools::Either::Right(linear.children.iter().copied()))
             }
-            Self::Grid(grid) => itertools::Either::Right(grid.children()),
+            Self::Grid(grid) => itertools::Either::Right(grid.children().copied()),
         }
     }
 

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -170,22 +170,20 @@ impl Tabs {
         }
     }
 
+    pub fn next_active<Pane>(&self, tiles: &Tiles<Pane>) -> Option<TileId> {
+        self.active
+            .filter(|active| tiles.is_visible(*active))
+            .or_else(|| {
+                self.children
+                    .iter()
+                    .copied()
+                    .find(|&child_id| tiles.is_visible(child_id))
+            })
+    }
+
     /// Make sure we have an active tab (or no visible tabs).
     pub fn ensure_active<Pane>(&mut self, tiles: &Tiles<Pane>) {
-        if let Some(active) = self.active {
-            if !tiles.is_visible(active) {
-                self.active = None;
-            }
-        }
-
-        if !self.children.iter().any(|&child| self.is_active(child)) {
-            // Make sure something is active:
-            self.active = self
-                .children
-                .iter()
-                .copied()
-                .find(|&child_id| tiles.is_visible(child_id));
-        }
+        self.active = self.next_active(tiles);
     }
 
     pub(super) fn ui<Pane>(

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -168,7 +168,7 @@ impl<Pane> Tiles<Pane> {
         tiles.push(tile_id);
 
         if let Some(Tile::Container(container)) = self.get(tile_id) {
-            for &child_id in container.active_children() {
+            for child_id in container.active_children(self) {
                 self.collect_active_tiles(child_id, tiles);
             }
         }


### PR DESCRIPTION
Right now `active_tiles` does not always reflect which tiles will be drawn. This fixes that.
