### PR TITLE
Add `Tiles::recompute_next_tile_id`

### DIFF
--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -201,6 +201,19 @@ impl<Pane> Tiles<Pane> {
 
         id
     }
+    /// Recomputes `next_tile_id` so that newly allocated tiles
+    /// will not collide with any existing `TileId` or any holes
+    /// left in the numbering.
+    ///
+    /// Note: this sets `next_tile_id` to the maximum existing `TileId`+1.
+    pub fn recompute_next_tile_id(&mut self) {
+        self.next_tile_id = self
+            .tiles
+            .keys()
+            .map(|tile_id| tile_id.0 + 1)
+            .max()
+            .unwrap_or(self.next_tile_id);
+    }
 
     #[must_use]
     pub fn insert_new(&mut self, tile: Tile<Pane>) -> TileId {


### PR DESCRIPTION
I added a function to recompute the `Tiles.next_tile_id` after building the `Tiles` manually with holes left in the `TileId` numbering.

I ended up in situation where I needed to build a `Tiles` manually based on a struct with its own numbering. When doing so, the `Tiles.next_tile_id` was not updated properly because I used `Tiles.insert` (which does not update `Tiles.next_tile_id`. Afterwards, when doing a tree simplification and adding `Tabs` container as parent for each `Pane`, then the same `TileId` was used for the new `Tabs` container and for the displaced `Pane`, making one disappear. 
My current solution (below) is to fill the `Tiles` with empty `Tabs` then computing `next_free_id()`, but it seemed more elegant and beneficial to have a function that do the update internally.
```rust
        let max_tile_id = value.containers.keys().max().copied().unwrap_or(1);
        for i in 1..max_tile_id {
            let tid = TileId(i as u64);
            if tiles.get(tid).is_none() {
                tiles.insert(tid, Tile::Container(Container::Tabs(Tabs::new(vec![]))));
            }
        }
        let id = tiles.next_free_id();
```

Best Regards,