### PR TITLE
Add `Behavior::is_tile_draggable` and `is_container_resizable`

### DIFF
--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -119,9 +119,18 @@ pub trait Behavior<Pane> {
             + f32::from(state.closable) * (close_btn_left_padding + close_btn_size.x);
         let (_, tab_rect) = ui.allocate_space(vec2(button_width, ui.available_height()));
 
-        let tab_response = ui
-            .interact(tab_rect, id, Sense::click_and_drag())
-            .on_hover_cursor(self.tab_hover_cursor_icon());
+        let draggable = self.is_tile_draggable(tiles, tile_id);
+        let sense = if draggable {
+            Sense::click_and_drag()
+        } else {
+            Sense::click()
+        };
+        let tab_response = ui.interact(tab_rect, id, sense);
+        let tab_response = if draggable {
+            tab_response.on_hover_cursor(self.tab_hover_cursor_icon())
+        } else {
+            tab_response
+        };
 
         // Show a gap when dragged
         if ui.is_rect_visible(tab_rect) && !state.is_being_dragged {
@@ -418,6 +427,25 @@ pub trait Behavior<Pane> {
     /// When using [`crate::GridLayout::Auto`], what is the ideal aspect ratio of a tile?
     fn ideal_tile_aspect_ratio(&self) -> f32 {
         4.0 / 3.0
+    }
+
+    /// Can this tile be dragged?
+    ///
+    /// If `false`, the tile cannot be dragged by the user.
+    /// This affects both tab dragging and pane dragging.
+    ///
+    /// Default: `true` (all tiles are draggable).
+    fn is_tile_draggable(&self, _tiles: &Tiles<Pane>, _tile_id: TileId) -> bool {
+        true
+    }
+
+    /// Can the children of this container be resized by dragging the separator?
+    ///
+    /// Only applies to [`crate::Linear`] and [`crate::Grid`] containers.
+    ///
+    /// Default: `true` (all containers are resizable).
+    fn is_container_resizable(&self, _tiles: &Tiles<Pane>, _tile_id: TileId) -> bool {
+        true
     }
 
     // Callbacks:

--- a/src/container/grid.rs
+++ b/src/container/grid.rs
@@ -281,11 +281,19 @@ impl Grid {
         ui: &egui::Ui,
         parent_id: TileId,
     ) {
+        let resizable = behavior.is_container_resizable(tiles, parent_id);
+
         let parent_rect = tiles.rect_or_die(parent_id);
         for (i, (left, right)) in self.col_ranges.iter().copied().tuple_windows().enumerate() {
             let resize_id = ui.id().with((parent_id, "resize_col", i));
 
             let x = egui::lerp(left.max..=right.min, 0.5);
+
+            if !resizable {
+                let stroke = behavior.resize_stroke(ui.style(), ResizeState::Idle);
+                ui.painter().vline(x, parent_rect.y_range(), stroke);
+                continue;
+            }
 
             let mut resize_state = ResizeState::Idle;
             let line_rect = Rect::from_center_size(
@@ -325,11 +333,19 @@ impl Grid {
         ui: &egui::Ui,
         parent_id: TileId,
     ) {
+        let resizable = behavior.is_container_resizable(tiles, parent_id);
+
         let parent_rect = tiles.rect_or_die(parent_id);
         for (i, (top, bottom)) in self.row_ranges.iter().copied().tuple_windows().enumerate() {
             let resize_id = ui.id().with((parent_id, "resize_row", i));
 
             let y = egui::lerp(top.max..=bottom.min, 0.5);
+
+            if !resizable {
+                let stroke = behavior.resize_stroke(ui.style(), ResizeState::Idle);
+                ui.painter().hline(parent_rect.x_range(), y, stroke);
+                continue;
+            }
 
             let mut resize_state = ResizeState::Idle;
             let line_rect = Rect::from_center_size(

--- a/src/container/linear.rs
+++ b/src/container/linear.rs
@@ -254,6 +254,8 @@ impl Linear {
         // ------------------------
         // resizing:
 
+        let resizable = behavior.is_container_resizable(&tree.tiles, parent_id);
+
         let parent_rect = tree.tiles.rect_or_die(parent_id);
         for (i, (left, right)) in visible_children.iter().copied().tuple_windows().enumerate() {
             let resize_id = ui.id().with((parent_id, "resize", i));
@@ -261,6 +263,12 @@ impl Linear {
             let left_rect = tree.tiles.rect_or_die(left);
             let right_rect = tree.tiles.rect_or_die(right);
             let x = egui::lerp(left_rect.right()..=right_rect.left(), 0.5);
+
+            if !resizable {
+                let stroke = behavior.resize_stroke(ui.style(), ResizeState::Idle);
+                ui.painter().vline(x, parent_rect.y_range(), stroke);
+                continue;
+            }
 
             let mut resize_state = ResizeState::Idle;
             let line_rect = Rect::from_center_size(
@@ -320,6 +328,8 @@ impl Linear {
         // ------------------------
         // resizing:
 
+        let resizable = behavior.is_container_resizable(&tree.tiles, parent_id);
+
         let parent_rect = tree.tiles.rect_or_die(parent_id);
         for (i, (top, bottom)) in visible_children.iter().copied().tuple_windows().enumerate() {
             let resize_id = ui.id().with((parent_id, "resize", i));
@@ -327,6 +337,12 @@ impl Linear {
             let top_rect = tree.tiles.rect_or_die(top);
             let bottom_rect = tree.tiles.rect_or_die(bottom);
             let y = egui::lerp(top_rect.bottom()..=bottom_rect.top(), 0.5);
+
+            if !resizable {
+                let stroke = behavior.resize_stroke(ui.style(), ResizeState::Idle);
+                ui.painter().hline(parent_rect.x_range(), y, stroke);
+                continue;
+            }
 
             let mut resize_state = ResizeState::Idle;
             let line_rect = Rect::from_center_size(

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -266,7 +266,9 @@ impl Tabs {
                         .horizontal_scroll_offset(scroll_state.offset);
 
                     let output = scroll_area.show(ui, |ui| {
-                        if !tree.is_root(tile_id) {
+                        if !tree.is_root(tile_id)
+                            && behavior.is_tile_draggable(&tree.tiles, tile_id)
+                        {
                             // Make the background behind the buttons draggable (to drag the parent container tile).
                             // We also sense clicks to avoid eager-dragging on mouse-down.
                             let sense = egui::Sense::click_and_drag();

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -403,7 +403,9 @@ impl<Pane> Tree<Pane> {
         ui.add_enabled_ui(enabled, |ui| {
             match &mut tile {
                 Tile::Pane(pane) => {
-                    if behavior.pane_ui(ui, tile_id, pane) == UiResponse::DragStarted {
+                    if behavior.pane_ui(ui, tile_id, pane) == UiResponse::DragStarted
+                        && behavior.is_tile_draggable(&self.tiles, tile_id)
+                    {
                         ui.ctx().set_dragged_id(tile_id.egui_id(self.id));
                     }
                 }


### PR DESCRIPTION
## Summary

- Add `Behavior::is_tile_draggable(tiles, tile_id) -> bool` — controls whether a tile can be dragged by the user. Affects tab button dragging, tab bar background dragging, and pane `DragStarted` response. Defaults to `true`.
- Add `Behavior::is_container_resizable(tiles, tile_id) -> bool` — controls whether resize handles between children of a Linear or Grid container are interactive. The separator line is still painted but cannot be dragged. Defaults to `true`.

Both methods default to `true`, so this is fully backward compatible.

This enables use cases like locked/fixed layouts where the tree structure should not be modified by the user, while still allowing selective per-tile/per-container control.

## Motivation

There is currently no way to prevent the user from dragging tabs or resizing splits. The workaround suggested in #93 (copy-pasting `tab_ui` and changing `Sense`) works for dragging but doesn't cover resize handles, tab bar background drag, or pane-initiated drag.

These two methods provide minimal, targeted control points without changing existing behavior.

## Changes

- **behavior.rs**: two new trait methods + `tab_ui` respects `is_tile_draggable` (switches `Sense::click_and_drag` → `Sense::click`)
- **tabs.rs**: tab bar background drag gated by `is_tile_draggable`
- **tree.rs**: pane `DragStarted` gated by `is_tile_draggable`
- **linear.rs**: resize handles gated by `is_container_resizable` (early continue, line still drawn)
- **grid.rs**: same for column/row resize handles

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — all 7 tests pass
- [x] Tested in a real application with locked layout (all drag disabled, selective resize)

Closes #93