### PR TITLE
Add Behavior::is_drop_allowed hook for drop zone filtering

### DIFF
--- a/examples/drop_filter.rs
+++ b/examples/drop_filter.rs
@@ -1,0 +1,197 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![allow(clippy::allow_attributes, unused_mut, clippy::useless_let_if_seq)]
+
+//! Example demonstrating `is_drop_allowed` hook.
+//! Each pane kind has different drop restrictions.
+
+use eframe::egui;
+use egui_tiles::{ContainerKind, TileId, Tiles};
+
+fn main() -> Result<(), eframe::Error> {
+    env_logger::init();
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([1100.0, 700.0]),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "egui_tiles — drop filter demo",
+        options,
+        Box::new(|_cc| Ok(Box::new(MyApp::default()))),
+    )
+}
+
+#[derive(Clone, Debug)]
+enum PaneKind {
+    /// Can be dropped anywhere, including splits
+    Free,
+    /// Only into existing tabs, no splits
+    TabsOnly,
+    /// Cannot be dropped into the restricted container
+    NoRight,
+    /// Not draggable at all
+    Pinned,
+}
+
+#[derive(Clone, Debug)]
+struct Pane {
+    nr: usize,
+    kind: PaneKind,
+}
+
+impl Pane {
+    fn color(&self) -> egui::Color32 {
+        match self.kind {
+            PaneKind::Free => egui::Color32::from_rgb(60, 140, 60),
+            PaneKind::TabsOnly => egui::Color32::from_rgb(60, 100, 160),
+            PaneKind::NoRight => egui::Color32::from_rgb(160, 100, 40),
+            PaneKind::Pinned => egui::Color32::from_rgb(140, 60, 60),
+        }
+    }
+
+    fn tag(&self) -> &'static str {
+        match self.kind {
+            PaneKind::Free => "free",
+            PaneKind::TabsOnly => "tabs-only",
+            PaneKind::NoRight => "no-right",
+            PaneKind::Pinned => "pinned",
+        }
+    }
+
+    fn label(&self) -> String {
+        format!("Pane {} ({})", self.nr, self.tag())
+    }
+
+    fn rules(&self) -> &'static [&'static str] {
+        match self.kind {
+            PaneKind::Free => &["Drop anywhere, including splits"],
+            PaneKind::TabsOnly => &[
+                "Only into existing tabs",
+                "No horizontal/vertical splits",
+            ],
+            PaneKind::NoRight => &[
+                "Cannot drop into the right container",
+                "Splits and tabs in left — OK",
+            ],
+            PaneKind::Pinned => &["Cannot be dragged at all"],
+        }
+    }
+}
+
+struct TreeBehavior {
+    restricted_container: TileId,
+}
+
+impl egui_tiles::Behavior<Pane> for TreeBehavior {
+    fn tab_title_for_pane(&mut self, pane: &Pane) -> egui::WidgetText {
+        pane.label().into()
+    }
+
+    fn pane_ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _tile_id: TileId,
+        pane: &mut Pane,
+    ) -> egui_tiles::UiResponse {
+        ui.painter().rect_filled(ui.max_rect(), 0.0, pane.color());
+        let text_color = egui::Color32::WHITE;
+        ui.label(egui::RichText::new(pane.label()).color(text_color).strong());
+        for rule in pane.rules() {
+            ui.label(egui::RichText::new(*rule).color(text_color));
+        }
+
+        // Pinned — not draggable, no drag sense
+        if matches!(pane.kind, PaneKind::Pinned) {
+            return egui_tiles::UiResponse::None;
+        }
+
+        let dragged = ui
+            .allocate_rect(ui.max_rect(), egui::Sense::click_and_drag())
+            .on_hover_cursor(egui::CursorIcon::Grab)
+            .dragged();
+        if dragged {
+            egui_tiles::UiResponse::DragStarted
+        } else {
+            egui_tiles::UiResponse::None
+        }
+    }
+
+    fn is_drop_allowed(
+        &self,
+        tiles: &Tiles<Pane>,
+        dragged_tile_id: TileId,
+        insertion: &egui_tiles::InsertionPoint,
+    ) -> bool {
+        let Some(egui_tiles::Tile::Pane(pane)) = tiles.get(dragged_tile_id) else {
+            return true;
+        };
+        let kind = insertion.container_kind();
+        match pane.kind {
+            PaneKind::Free => true,
+            PaneKind::TabsOnly => kind == ContainerKind::Tabs,
+            PaneKind::NoRight => insertion.parent_id != self.restricted_container,
+            // Pinned should never reach here (is_tile_draggable = false),
+            // but just in case
+            PaneKind::Pinned => false,
+        }
+    }
+
+    fn is_tile_draggable(
+        &self,
+        tiles: &Tiles<Pane>,
+        tile_id: TileId,
+    ) -> bool {
+        if let Some(egui_tiles::Tile::Pane(pane)) = tiles.get(tile_id) {
+            !matches!(pane.kind, PaneKind::Pinned)
+        } else {
+            true
+        }
+    }
+}
+
+struct MyApp {
+    tree: egui_tiles::Tree<Pane>,
+    restricted_container: TileId,
+}
+
+impl Default for MyApp {
+    fn default() -> Self {
+        let mut tiles = egui_tiles::Tiles::default();
+
+        // Left side: one of each kind
+        let left_children: Vec<TileId> = vec![
+            tiles.insert_pane(Pane { nr: 0, kind: PaneKind::Free }),
+            tiles.insert_pane(Pane { nr: 1, kind: PaneKind::TabsOnly }),
+            tiles.insert_pane(Pane { nr: 2, kind: PaneKind::NoRight }),
+            tiles.insert_pane(Pane { nr: 3, kind: PaneKind::Pinned }),
+        ];
+        let left = tiles.insert_tab_tile(left_children);
+
+        // Right side: Free + TabsOnly
+        let right_children: Vec<TileId> = vec![
+            tiles.insert_pane(Pane { nr: 4, kind: PaneKind::Free }),
+            tiles.insert_pane(Pane { nr: 5, kind: PaneKind::TabsOnly }),
+        ];
+        let right = tiles.insert_tab_tile(right_children);
+
+        let root = tiles.insert_horizontal_tile(vec![left, right]);
+        let tree = egui_tiles::Tree::new("drop_filter_tree", root, tiles);
+
+        Self {
+            tree,
+            restricted_container: right,
+        }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        ui.heading("Drop filter demo");
+        ui.label("Drag tabs between containers. Each pane type has different restrictions.");
+        ui.separator();
+
+        let mut behavior = TreeBehavior {
+            restricted_container: self.restricted_container,
+        };
+        self.tree.ui(&mut behavior, ui);
+    }
+}

--- a/examples/drop_filter.rs
+++ b/examples/drop_filter.rs
@@ -64,10 +64,7 @@ impl Pane {
     fn rules(&self) -> &'static [&'static str] {
         match self.kind {
             PaneKind::Free => &["Drop anywhere, including splits"],
-            PaneKind::TabsOnly => &[
-                "Only into existing tabs",
-                "No horizontal/vertical splits",
-            ],
+            PaneKind::TabsOnly => &["Only into existing tabs", "No horizontal/vertical splits"],
             PaneKind::NoRight => &[
                 "Cannot drop into the right container",
                 "Splits and tabs in left — OK",
@@ -135,11 +132,7 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
         }
     }
 
-    fn is_tile_draggable(
-        &self,
-        tiles: &Tiles<Pane>,
-        tile_id: TileId,
-    ) -> bool {
+    fn is_tile_draggable(&self, tiles: &Tiles<Pane>, tile_id: TileId) -> bool {
         if let Some(egui_tiles::Tile::Pane(pane)) = tiles.get(tile_id) {
             !matches!(pane.kind, PaneKind::Pinned)
         } else {
@@ -159,17 +152,35 @@ impl Default for MyApp {
 
         // Left side: one of each kind
         let left_children: Vec<TileId> = vec![
-            tiles.insert_pane(Pane { nr: 0, kind: PaneKind::Free }),
-            tiles.insert_pane(Pane { nr: 1, kind: PaneKind::TabsOnly }),
-            tiles.insert_pane(Pane { nr: 2, kind: PaneKind::NoRight }),
-            tiles.insert_pane(Pane { nr: 3, kind: PaneKind::Pinned }),
+            tiles.insert_pane(Pane {
+                nr: 0,
+                kind: PaneKind::Free,
+            }),
+            tiles.insert_pane(Pane {
+                nr: 1,
+                kind: PaneKind::TabsOnly,
+            }),
+            tiles.insert_pane(Pane {
+                nr: 2,
+                kind: PaneKind::NoRight,
+            }),
+            tiles.insert_pane(Pane {
+                nr: 3,
+                kind: PaneKind::Pinned,
+            }),
         ];
         let left = tiles.insert_tab_tile(left_children);
 
         // Right side: Free + TabsOnly
         let right_children: Vec<TileId> = vec![
-            tiles.insert_pane(Pane { nr: 4, kind: PaneKind::Free }),
-            tiles.insert_pane(Pane { nr: 5, kind: PaneKind::TabsOnly }),
+            tiles.insert_pane(Pane {
+                nr: 4,
+                kind: PaneKind::Free,
+            }),
+            tiles.insert_pane(Pane {
+                nr: 5,
+                kind: PaneKind::TabsOnly,
+            }),
         ];
         let right = tiles.insert_tab_tile(right_children);
 

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -3,7 +3,7 @@ use egui::{
     vec2,
 };
 
-use super::{ResizeState, SimplificationOptions, Tile, TileId, Tiles, UiResponse};
+use super::{InsertionPoint, ResizeState, SimplificationOptions, Tile, TileId, Tiles, UiResponse};
 
 /// The kind of edit that triggered the call to [`Behavior::on_edit`].
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -384,6 +384,16 @@ pub trait Behavior<Pane> {
         visuals.selection.stroke.color.gamma_multiply(0.5)
     }
 
+    /// Color for the drop preview when [`Self::is_drop_allowed`] returns `false`.
+    fn drag_preview_color_rejected(&self, _visuals: &Visuals) -> Color32 {
+        Color32::from_rgba_premultiplied(180, 40, 40, 100)
+    }
+
+    /// Stroke for the drop preview when [`Self::is_drop_allowed`] returns `false`.
+    fn drag_preview_stroke_rejected(&self, _visuals: &Visuals) -> Stroke {
+        Stroke::new(1.0, Color32::from_rgb(200, 60, 60))
+    }
+
     /// When drag-and-dropping a tile, how do we preview what is about to happen?
     fn paint_drag_preview(
         &self,
@@ -437,6 +447,22 @@ pub trait Behavior<Pane> {
     ///
     /// Default: `true` (all tiles are draggable).
     fn is_tile_draggable(&self, _tiles: &Tiles<Pane>, _tile_id: TileId) -> bool {
+        true
+    }
+
+    /// Can the dragged tile be dropped at the given insertion point?
+    ///
+    /// Called once per frame with the best (closest to cursor) candidate insertion point.
+    /// If `false`, the drop preview is drawn in the rejected color
+    /// (see [`Self::drag_preview_color_rejected`]) and the drop is not performed.
+    ///
+    /// Default: `true` (all drops are allowed).
+    fn is_drop_allowed(
+        &self,
+        _tiles: &Tiles<Pane>,
+        _dragged_tile_id: TileId,
+        _insertion: &InsertionPoint,
+    ) -> bool {
         true
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,19 +256,29 @@ impl ContainerInsertion {
 
 /// Where in the tree to insert a tile.
 #[derive(Clone, Copy, Debug)]
-struct InsertionPoint {
+pub struct InsertionPoint {
+    /// Which container will receive the dropped tile.
     pub parent_id: TileId,
 
     /// Where in the parent?
-    pub insertion: ContainerInsertion,
+    pub(crate) insertion: ContainerInsertion,
 }
 
 impl InsertionPoint {
-    pub fn new(parent_id: TileId, insertion: ContainerInsertion) -> Self {
+    pub(crate) fn new(parent_id: TileId, insertion: ContainerInsertion) -> Self {
         Self {
             parent_id,
             insertion,
         }
+    }
+
+    /// What kind of container layout the drop will create or insert into.
+    ///
+    /// If `parent_id` is a pane, this is the kind of container that will
+    /// **replace** it (splitting the pane). If `parent_id` is already a
+    /// container of this kind, the tile is inserted into it.
+    pub fn container_kind(&self) -> ContainerKind {
+        self.insertion.kind()
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -460,6 +460,12 @@ impl<Pane> Tree<Pane> {
                 behavior.drag_ui(&self.tiles, ui, dragged_tile_id);
             });
 
+        // Check is_drop_allowed for the best candidate zone
+        let can_drop = drop_context
+            .best_insertion
+            .map(|ins| behavior.is_drop_allowed(&self.tiles, dragged_tile_id, &ins))
+            .unwrap_or(false);
+
         if let Some(preview_rect) = drop_context.preview_rect {
             let preview_rect = smooth_preview_rect(ui, dragged_tile_id, preview_rect);
 
@@ -467,9 +473,19 @@ impl<Pane> Tree<Pane> {
                 .best_insertion
                 .and_then(|insertion_point| self.tiles.rect(insertion_point.parent_id));
 
-            behavior.paint_drag_preview(ui.visuals(), ui.painter(), parent_rect, preview_rect);
+            if can_drop {
+                behavior.paint_drag_preview(ui.visuals(), ui.painter(), parent_rect, preview_rect);
+            } else {
+                // Rejected zone — red preview
+                let color = behavior.drag_preview_color_rejected(ui.visuals());
+                let stroke = behavior.drag_preview_stroke_rejected(ui.visuals());
+                if let Some(parent_rect) = parent_rect {
+                    ui.painter().rect_stroke(parent_rect, 1.0, stroke, egui::StrokeKind::Inside);
+                }
+                ui.painter().rect(preview_rect, 1.0, color, stroke, egui::StrokeKind::Inside);
+            }
 
-            if behavior.preview_dragged_panes() {
+            if can_drop && behavior.preview_dragged_panes() {
                 // TODO(emilk): add support for previewing containers too.
                 if preview_rect.width() > 32.0
                     && preview_rect.height() > 32.0
@@ -487,7 +503,9 @@ impl<Pane> Tree<Pane> {
         }
 
         if ui.input(|i| i.pointer.any_released()) {
-            if let Some(insertion_point) = drop_context.best_insertion {
+            if can_drop
+                && let Some(insertion_point) = drop_context.best_insertion
+            {
                 behavior.on_edit(EditAction::TileDropped);
                 self.move_tile(dragged_tile_id, insertion_point, false);
             }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -480,9 +480,11 @@ impl<Pane> Tree<Pane> {
                 let color = behavior.drag_preview_color_rejected(ui.visuals());
                 let stroke = behavior.drag_preview_stroke_rejected(ui.visuals());
                 if let Some(parent_rect) = parent_rect {
-                    ui.painter().rect_stroke(parent_rect, 1.0, stroke, egui::StrokeKind::Inside);
+                    ui.painter()
+                        .rect_stroke(parent_rect, 1.0, stroke, egui::StrokeKind::Inside);
                 }
-                ui.painter().rect(preview_rect, 1.0, color, stroke, egui::StrokeKind::Inside);
+                ui.painter()
+                    .rect(preview_rect, 1.0, color, stroke, egui::StrokeKind::Inside);
             }
 
             if can_drop && behavior.preview_dragged_panes() {
@@ -503,9 +505,7 @@ impl<Pane> Tree<Pane> {
         }
 
         if ui.input(|i| i.pointer.any_released()) {
-            if can_drop
-                && let Some(insertion_point) = drop_context.best_insertion
-            {
+            if can_drop && let Some(insertion_point) = drop_context.best_insertion {
                 behavior.on_edit(EditAction::TileDropped);
                 self.move_tile(dragged_tile_id, insertion_point, false);
             }


### PR DESCRIPTION
## Summary

This is an **experimental / RFC** PR — we don't necessarily expect it to be merged as-is. We'd love feedback on the API design and would be happy if people try the example!

Adds a `Behavior::is_drop_allowed` hook that lets users control which drop zones accept which tiles. When a drop is rejected, the preview rectangle is drawn in **red** instead of the default selection color, so the user gets immediate visual feedback.

### New API surface

- `Behavior::is_drop_allowed(&self, tiles, dragged_tile_id, &InsertionPoint) -> bool` — called once per frame for the best candidate; return `false` to block the drop
- `Behavior::drag_preview_color_rejected` / `drag_preview_stroke_rejected` — customizable rejected-zone appearance  
- `InsertionPoint` is now `pub` with a `parent_id: TileId` field and a `container_kind() -> ContainerKind` accessor, so the hook can inspect *where* and *how* the tile would be inserted

### Example

**Please try `cargo run --example drop_filter`** — it's a small interactive demo with four pane types, each having different drop restrictions:

| Color | Type | Rules |
|-------|------|-------|
| 🟢 Green | **Free** | Can be dropped anywhere, including splits |
| 🔵 Blue | **TabsOnly** | Only into existing tab containers, no H/V splits |
| 🟠 Orange | **NoRight** | Cannot enter the right-side container |
| 🔴 Red | **Pinned** | Not draggable at all |

Drag them around and watch the preview turn red when a drop would be rejected.

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` clean
- [x] `cargo run --example drop_filter` — manual verification of all four restriction types
- [ ] Feedback on API design welcome

## Design alternatives considered

We explored several approaches before settling on this one:

**Where to check:**
- **(a) Filter at `suggest_rect`** — don't register rejected zones at all, so the nearest *allowed* zone wins. More invasive (need to thread `behavior`+`tiles` through `DropContext` and every `suggest_rect` call site). UX downside: user sees nothing and doesn't understand why a zone is ignored.
- **(b) Reject at `move_tile`** — post-hoc, on release. Minimal diff, but green preview says "allowed" and then nothing happens — confusing.
- **(c) Check the winner in `preview_dragged_tile`** ✅ — one check, red/green feedback, minimal diff.

**One tracker vs two:**
- **(a) Two trackers** (`best_allowed` + `best_any`) — when cursor is over a rejected zone, still drop into the nearest *allowed* one. More complex; the "magnet to a distant zone" behavior can feel unpredictable.
- **(b) Single `can_drop` flag** ✅ — if the nearest zone is rejected, drop simply doesn't happen. User must move the cursor to an allowed zone. Simpler and more predictable.

**What to expose in `InsertionPoint`:**
- **(a) Only `parent_id`** — can't distinguish "add to tabs" from "split horizontally".
- **(b) `parent_id` + `container_kind()`** ✅ — enough to tell tabs vs splits; index stays `pub(crate)`.
- **(c) Fully public `ContainerInsertion`** — exposes internal index, rarely useful for the decision.

**Visual indication:**
- **(a) Silently ignore** — no highlight at all (variant (a) from "where to check").
- **(b) Red preview** ✅ — clear visual signal.
- **(c) `NotAllowed` cursor** — could be layered on top of (b), not done yet.

---

This PR was entirely crafted by Claude (claude-code), under the careful supervision of @enomado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)