### PR TITLE
Fix lychee link checker CI

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -30,4 +30,4 @@ jobs:
           fail: true
           # When given a directory, lychee checks only markdown, html and text files, everything else we have to glob in manually.
           args: |
-            --base . --cache --max-cache-age 1d . "**/*.rs" "**/*.toml" "**/*.hpp" "**/*.cpp" "**/CMakeLists.txt" "**/*.py" "**/*.yml"
+            --base ${{ github.workspace }} --cache --max-cache-age 1d . "**/*.rs" "**/*.toml" "**/*.hpp" "**/*.cpp" "**/CMakeLists.txt" "**/*.py" "**/*.yml"


### PR DESCRIPTION
## Summary
- lychee v0.23+ requires `--base` to be a URL or an absolute path — relative `.` is no longer accepted
- Replace `--base .` with `--base ${{ github.workspace }}` to fix the "Check links" job that has been failing on every PR

## Test plan
- [ ] Verify "Check links" CI passes on this PR