### PR TITLE
Add `Behavior::tab_bar_trailing_ui` (trailing tab-bar slot)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
 # `egui_tiles` Changelog
 
 
-## Unreleased
-* Add `Behavior::tab_bar_trailing_ui` for rendering UI immediately after the last tab [#132](https://github.com/rerun-io/egui_tiles/issues/132) by [@mitchmindtree](https://github.com/mitchmindtree)
-
-
 ## 0.15.0 - 2026-03-27
 Full diff at https://github.com/rerun-io/egui_tiles/compare/0.14.0..HEAD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # `egui_tiles` Changelog
 
 
+## Unreleased
+* Add `Behavior::tab_bar_trailing_ui` for rendering UI immediately after the last tab [#132](https://github.com/rerun-io/egui_tiles/issues/132) by [@mitchmindtree](https://github.com/mitchmindtree)
+
+
 ## 0.15.0 - 2026-03-27
 Full diff at https://github.com/rerun-io/egui_tiles/compare/0.14.0..HEAD
 

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -140,6 +140,22 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
         }
     }
 
+    fn tab_bar_trailing_ui(
+        &mut self,
+        _tiles: &egui_tiles::Tiles<Pane>,
+        ui: &mut egui::Ui,
+        tile_id: egui_tiles::TileId,
+        _tabs: &egui_tiles::Tabs,
+    ) {
+        if ui
+            .button("➕")
+            .on_hover_text("Add a new tab (rendered right after the last tab)")
+            .clicked()
+        {
+            self.add_child_to = Some(tile_id);
+        }
+    }
+
     // ---
     // Settings:
 

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -272,8 +272,6 @@ pub trait Behavior<Pane> {
         _tile_id: TileId,
         _tabs: &crate::Tabs,
     ) {
-        // if ui.button("➕").clicked() {
-        // }
     }
 
     /// The height of the bar holding tab titles.

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -254,6 +254,28 @@ pub trait Behavior<Pane> {
         // }
     }
 
+    /// Adds some UI to the tab bar immediately after the last tab.
+    ///
+    /// This is rendered inside the tab scroll area's left-to-right flow, so it
+    /// scrolls together with the tabs and sits right after the last visible tab
+    /// (e.g. a browser-style "➕" button for adding a new tab).
+    ///
+    /// Note: item spacing inside the tab flow is zero, so add your own spacing
+    /// (e.g. `ui.add_space(..)`) if you want a gap before your widget.
+    ///
+    /// Compare with [`Self::top_bar_right_ui`], which pins widgets to the far
+    /// right of the tab bar.
+    fn tab_bar_trailing_ui(
+        &mut self,
+        _tiles: &Tiles<Pane>,
+        _ui: &mut Ui,
+        _tile_id: TileId,
+        _tabs: &crate::Tabs,
+    ) {
+        // if ui.button("➕").clicked() {
+        // }
+    }
+
     /// The height of the bar holding tab titles.
     fn tab_bar_height(&self, _style: &egui::Style) -> f32 {
         24.0

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -326,6 +326,10 @@ impl Tabs {
                                 dragged_index = Some(i);
                             }
                         }
+
+                        // Allow the user to add a trailing widget after the last tab
+                        // (e.g. a "➕" button), inside the tab scroll area's flow.
+                        behavior.tab_bar_trailing_ui(&tree.tiles, ui, tile_id, self);
                     });
 
                     scroll_state.offset = output.state.offset.x;


### PR DESCRIPTION
Closes #132.

## Summary

`top_bar_right_ui` can only pin widgets to the **far right** of the tab bar, separated from the tabs by fill space. There was no way to render a widget **immediately after the last tab** (browser-style "new tab" `+`), since the tabs live in a fill-width scroll area with no hook after the last tab.

This adds a first-class `Behavior::tab_bar_trailing_ui` method, called once inside the tab scroll area right after the tab loop, so the widget renders in the tabs' left-to-right flow and scrolls with them.

## Changes

- `src/behavior.rs` - new `tab_bar_trailing_ui` trait method with a default empty impl (existing behaviors are unaffected). Mirrors `top_bar_right_ui`, minus `scroll_offset` (the call is already inside the scroll area).
- `src/container/tabs.rs` - single call site inside the scroll area, right after the `for child in self.children` loop.
- `examples/advanced.rs` - demonstrate a trailing `+` alongside the existing far-right `+`, so the two slots can be compared.
- `CHANGELOG.md` - changelog entry.

```rust
/// Adds some UI to the tab bar immediately after the last tab.
fn tab_bar_trailing_ui(
    &mut self,
    _tiles: &Tiles<Pane>,
    _ui: &mut Ui,
    _tile_id: TileId,
    _tabs: &Tabs,
) {}
```