### PR TITLE
Fix unstable widget IDs for tab scroll arrows

### DIFF
--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -100,36 +100,43 @@ impl ScrollState {
         (self.available.x / 3.0).at_least(20.0)
     }
 
-    pub fn left_arrow(&mut self, ui: &mut egui::Ui, arrow_size: Vec2) {
+    fn arrow_button(ui: &mut egui::Ui, arrow_size: Vec2, id: egui::Id, glyph: &str) -> bool {
+        let glyph_size = arrow_size.y * 0.5;
+        ui.scope_builder(egui::UiBuilder::new().id(id), |ui| {
+            ui.add_sized(
+                arrow_size,
+                egui::Button::new(egui::RichText::new(glyph).size(glyph_size)),
+            )
+        })
+        .inner
+        .clicked()
+    }
+
+    fn hidden_arrow_marker(ui: &egui::Ui, arrow_size: Vec2, id: egui::Id) {
+        let rect = ui
+            .layout()
+            .align_size_within_rect(arrow_size, ui.available_rect_before_wrap());
+        ui.interact(rect, id, egui::Sense::hover());
+    }
+
+    pub fn left_arrow(&mut self, ui: &mut egui::Ui, arrow_size: Vec2, id: egui::Id) {
         if !self.show_left_arrow {
+            Self::hidden_arrow_marker(ui, arrow_size, id);
             return;
         }
 
-        let glyph_size = arrow_size.y * 0.5;
-        if ui
-            .add_sized(
-                arrow_size,
-                egui::Button::new(egui::RichText::new("⏴").size(glyph_size)),
-            )
-            .clicked()
-        {
+        if Self::arrow_button(ui, arrow_size, id, "⏴") {
             self.offset_debt -= self.scroll_increment();
         }
     }
 
-    pub fn right_arrow(&mut self, ui: &mut egui::Ui, arrow_size: Vec2) {
+    pub fn right_arrow(&mut self, ui: &mut egui::Ui, arrow_size: Vec2, id: egui::Id) {
         if !self.show_right_arrow {
+            Self::hidden_arrow_marker(ui, arrow_size, id);
             return;
         }
 
-        let glyph_size = arrow_size.y * 0.5;
-        if ui
-            .add_sized(
-                arrow_size,
-                egui::Button::new(egui::RichText::new("⏵").size(glyph_size)),
-            )
-            .clicked()
-        {
+        if Self::arrow_button(ui, arrow_size, id, "⏵") {
             self.offset_debt += self.scroll_increment();
         }
     }
@@ -249,13 +256,15 @@ impl Tabs {
             let scroll_area_width = scroll_state.update(ui, arrow_size);
 
             // We're in a right-to-left layout, so start with the right scroll-arrow:
-            scroll_state.right_arrow(ui, arrow_size);
+            let right_arrow_id = ui.make_persistent_id((tile_id, "right_scroll_arrow"));
+            scroll_state.right_arrow(ui, arrow_size, right_arrow_id);
 
             ui.allocate_ui_with_layout(
                 ui.available_size(),
                 egui::Layout::left_to_right(egui::Align::Center),
                 |ui| {
-                    scroll_state.left_arrow(ui, arrow_size);
+                    let left_arrow_id = ui.make_persistent_id((tile_id, "left_scroll_arrow"));
+                    scroll_state.left_arrow(ui, arrow_size, left_arrow_id);
 
                     // Prepare to show the scroll area with the tabs:
 


### PR DESCRIPTION
Fixes tab-bar interaction state shifting when scroll arrows appear or disappear.

- Assigns persistent IDs to the left and right scroll arrows, scoped by tile ID.
- Isolates visible arrow buttons within stable ID scopes.
- Registers hidden arrow markers to keep subsequent widget IDs stable across frames
