### PR TITLE
Add an example for apps that rebuild the tree every frame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "accesskit_consumer"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,12 +663,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_kittest"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "002c31e1f41461ce206333ffbd2e07563b79e87eb71c27e026151d12ee7b78e0"
+dependencies = [
+ "egui",
+ "kittest",
+ "log",
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "egui_tiles"
 version = "0.16.0"
 dependencies = [
  "ahash",
  "eframe",
  "egui",
+ "egui_kittest",
  "env_logger",
  "itertools 0.15.0",
  "log",
@@ -1387,6 +1411,16 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kittest"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ceaa75eb0036a32b6b9833962eb18137449e9817e2e586006471925b727fd5"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+]
 
 [[package]]
 name = "kurbo"
@@ -2330,6 +2364,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,10 +2589,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -2561,18 +2626,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.2",
  "toml_parser",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.3"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3349,6 +3414,12 @@ checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,9 @@ env_logger = { version = "0.11.8", default-features = false, features = [
 ] }
 
 # For tests:
-serde_json = "1.0.149"
+egui_kittest = "0.35.0"
 ron = "0.12.2"
+serde_json = "1.0.149"
 
 
 [patch.crates-io]

--- a/examples/tree_recreated_every_frame.rs
+++ b/examples/tree_recreated_every_frame.rs
@@ -117,7 +117,9 @@ impl Blueprint {
                 Node::Pane { id } => {
                     let id_ = tile_id(id);
                     tiles.insert(id_, Tile::Pane(id.clone()));
-                    reverse.insert(id_, id.clone());
+                    // Deliberately NOT in `reverse`: a pane carries its own app id as its
+                    // payload, and `reverse` is only consulted for containers. Putting panes in
+                    // here is a trap -- see the note on `sync_from_tree`.
                     id_
                 }
                 Node::Container { id, kind, children } => {
@@ -137,6 +139,20 @@ impl Blueprint {
 
     /// Fold an edited tree back into the blueprint, minting fresh ids for any newly-created
     /// containers (tiles whose id isn't in `reverse`) — exactly what Rerun does on a drop.
+    ///
+    /// ## Watch out
+    ///
+    /// `reverse` maps a `TileId` back to an app id, and it deliberately contains **containers
+    /// only**. Panes are looked up from their own payload instead.
+    ///
+    /// That matters because a `TileId` does not keep referring to the same kind of tile. Drop a
+    /// pane onto another pane and `egui_tiles` reuses the *target's* id for the new container it
+    /// wraps them both in, moving the target pane itself to a freshly allocated id. So a tile id
+    /// that meant `"pane_a"` one frame can mean `"the container holding pane_a"` the next.
+    ///
+    /// If panes were in `reverse`, that new container would be handed the app id `"pane_a"`, and
+    /// the next `to_tree()` would insert both a pane and a container at `tile_id("pane_a")` — the
+    /// second overwriting the first, silently losing a pane.
     fn sync_from_tree(&mut self, tree: &Tree<String>, reverse: &HashMap<TileId, String>) {
         fn rebuild(
             tile_id: TileId,

--- a/examples/tree_recreated_every_frame.rs
+++ b/examples/tree_recreated_every_frame.rs
@@ -1,0 +1,244 @@
+//! Reproduces how Rerun (and similar apps) drive `egui_tiles`:
+//!
+//! The tree is NOT the source of truth. Instead the app keeps its own model (here `Blueprint`)
+//! and **re-creates the [`egui_tiles::Tree`] from scratch every single frame**, assigning each
+//! tile a stable [`TileId`] derived from a hash of the app's own id — never from
+//! `Tiles::insert_new`'s running counter. After [`Tree::ui`], any edit is read back out of the
+//! tree and folded into the `Blueprint`, so it persists into the next frame's freshly-built tree.
+//!
+//! This setup is easy for `egui_tiles` to get wrong: anything that edits the tree mid-frame and
+//! expects to put it back the way it was has to survive the tree being thrown away and rebuilt
+//! underneath it. Run this, drag panes around, and watch the "panes" counter in the top bar —
+//! it must stay constant.
+
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+use std::collections::HashMap;
+use std::hash::{Hash as _, Hasher as _};
+
+use egui_tiles::{Container, ContainerKind, Tile, TileId, Tiles, Tree};
+
+// ----------------------------------------------------------------------------
+// The app's own source of truth — analogous to Rerun's blueprint.
+
+/// A node in the app's own layout model, identified by a stable string id.
+#[derive(Clone)]
+enum Node {
+    Pane {
+        id: String,
+    },
+    Container {
+        id: String,
+        kind: ContainerKind,
+        children: Vec<Self>,
+    },
+}
+
+impl Node {
+    fn pane(id: impl Into<String>) -> Self {
+        Self::Pane { id: id.into() }
+    }
+
+    fn container(id: impl Into<String>, kind: ContainerKind, children: Vec<Self>) -> Self {
+        Self::Container {
+            id: id.into(),
+            kind,
+            children,
+        }
+    }
+
+    fn count_panes(&self) -> usize {
+        match self {
+            Self::Pane { .. } => 1,
+            Self::Container { children, .. } => children.iter().map(Self::count_panes).sum(),
+        }
+    }
+}
+
+struct Blueprint {
+    root: Node,
+    /// Monotonic source for fresh ids when the tree grows a container we've never seen.
+    next_generated_id: u64,
+}
+
+impl Default for Blueprint {
+    fn default() -> Self {
+        // Nested containers of three different kinds, so that dragging things around exercises
+        // the interesting cases: splitting a pane, joining a linear container, moving a tile
+        // between containers, and dropping into a tab bar.
+        //
+        //   Horizontal[ pane_a, Vertical[ pane_b, Tabs[ pane_c, pane_d ] ] ]
+        Self {
+            root: Node::container(
+                "root",
+                ContainerKind::Horizontal,
+                vec![
+                    Node::pane("pane_a"),
+                    Node::container(
+                        "right_column",
+                        ContainerKind::Vertical,
+                        vec![
+                            Node::pane("pane_b"),
+                            Node::container(
+                                "bottom_tabs",
+                                ContainerKind::Tabs,
+                                vec![Node::pane("pane_c"), Node::pane("pane_d")],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            next_generated_id: 0,
+        }
+    }
+}
+
+/// Stable [`TileId`] from an app id — deterministic, so re-creating the tree yields the same ids.
+fn tile_id(app_id: &str) -> TileId {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    app_id.hash(&mut hasher);
+    TileId::from_u64(hasher.finish())
+}
+
+impl Blueprint {
+    /// Build a fresh [`Tree`] from the blueprint, and a `TileId -> app id` reverse map.
+    ///
+    /// Mirrors Rerun: tiles get hash-based ids via [`Tiles::insert`], so `next_tile_id` stays 0.
+    fn to_tree(&self) -> (Tree<String>, HashMap<TileId, String>) {
+        let mut tiles = Tiles::default();
+        let mut reverse = HashMap::new();
+
+        fn insert(
+            node: &Node,
+            tiles: &mut Tiles<String>,
+            reverse: &mut HashMap<TileId, String>,
+        ) -> TileId {
+            match node {
+                Node::Pane { id } => {
+                    let id_ = tile_id(id);
+                    tiles.insert(id_, Tile::Pane(id.clone()));
+                    reverse.insert(id_, id.clone());
+                    id_
+                }
+                Node::Container { id, kind, children } => {
+                    let child_ids = children.iter().map(|c| insert(c, tiles, reverse)).collect();
+                    let container = Container::new(*kind, child_ids);
+                    let id_ = tile_id(id);
+                    tiles.insert(id_, Tile::Container(container));
+                    reverse.insert(id_, id.clone());
+                    id_
+                }
+            }
+        }
+
+        let root = insert(&self.root, &mut tiles, &mut reverse);
+        (Tree::new("rerun_style_tree", root, tiles), reverse)
+    }
+
+    /// Fold an edited tree back into the blueprint, minting fresh ids for any newly-created
+    /// containers (tiles whose id isn't in `reverse`) — exactly what Rerun does on a drop.
+    fn sync_from_tree(&mut self, tree: &Tree<String>, reverse: &HashMap<TileId, String>) {
+        fn rebuild(
+            tile_id: TileId,
+            tree: &Tree<String>,
+            reverse: &HashMap<TileId, String>,
+            next: &mut u64,
+        ) -> Option<Node> {
+            match tree.tiles.get(tile_id)? {
+                Tile::Pane(app_id) => Some(Node::Pane { id: app_id.clone() }),
+                Tile::Container(container) => {
+                    let id = reverse.get(&tile_id).cloned().unwrap_or_else(|| {
+                        let generated = format!("generated_container_{next}");
+                        *next += 1;
+                        generated
+                    });
+                    let children = container
+                        .children()
+                        .filter_map(|&c| rebuild(c, tree, reverse, next))
+                        .collect();
+                    Some(Node::Container {
+                        id,
+                        kind: container.kind(),
+                        children,
+                    })
+                }
+            }
+        }
+
+        if let Some(root) = tree.root
+            && let Some(node) = rebuild(root, tree, reverse, &mut self.next_generated_id)
+        {
+            self.root = node;
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+struct TreeBehavior;
+
+impl egui_tiles::Behavior<String> for TreeBehavior {
+    fn tab_title_for_pane(&mut self, pane: &String) -> egui::WidgetText {
+        pane.clone().into()
+    }
+
+    fn pane_ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _tile_id: TileId,
+        pane: &mut String,
+    ) -> egui_tiles::UiResponse {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        pane.hash(&mut hasher);
+        let hue = (hasher.finish() % 360) as f32 / 360.0;
+        let color = egui::epaint::Hsva::new(hue, 0.5, 0.5, 1.0);
+        ui.painter().rect_filled(ui.max_rect(), 0.0, color);
+
+        ui.heading(pane.as_str());
+        if ui
+            .add(egui::Button::new("Drag me!").sense(egui::Sense::drag()))
+            .drag_started()
+        {
+            egui_tiles::UiResponse::DragStarted
+        } else {
+            egui_tiles::UiResponse::None
+        }
+    }
+}
+
+fn main() -> Result<(), eframe::Error> {
+    env_logger::init(); // `Tile #N not found`-style warnings show up here with `RUST_LOG=warn`.
+
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([700.0, 500.0]),
+        ..Default::default()
+    };
+
+    let mut blueprint = Blueprint::default();
+
+    eframe::run_ui_native(
+        "egui_tiles: tree re-created every frame",
+        options,
+        move |ui, _frame| {
+            egui::CentralPanel::default().show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label(format!("panes: {}", blueprint.root.count_panes()));
+                    ui.label("← must stay constant while you drag panes around");
+                    if ui.button("Reset").clicked() {
+                        blueprint = Blueprint::default();
+                    }
+                });
+                ui.separator();
+
+                // Rebuild the tree from the blueprint every frame:
+                let (mut tree, reverse) = blueprint.to_tree();
+
+                let mut behavior = TreeBehavior;
+                tree.ui(&mut behavior, ui);
+
+                // Fold any edit back into the blueprint so it survives the next rebuild:
+                blueprint.sync_from_tree(&tree, &reverse);
+            });
+        },
+    )
+}

--- a/tests/tree_recreated_every_frame.rs
+++ b/tests/tree_recreated_every_frame.rs
@@ -1,0 +1,313 @@
+//! Tests the pattern in `examples/tree_recreated_every_frame.rs`: an app that owns its own layout
+//! model and re-creates the [`Tree`] from scratch every frame, with `TileId`s derived from its own
+//! stable ids rather than from `Tiles::insert_new`'s counter.
+//!
+//! Two constraints fall out of that, and both are easy to break:
+//!
+//! 1. Any state that has to outlive a frame cannot live in the `Tree` — it gets thrown away.
+//! 2. Anything that edits the tree mid-frame and expects to put it back has to cope with the tree
+//!    being discarded and rebuilt underneath it.
+//!
+//! Breaking either tends to show up as a silently lost pane rather than a compile error, so: drag
+//! panes around and check that none go missing.
+
+use std::collections::HashMap;
+use std::hash::{Hash as _, Hasher as _};
+
+use egui_kittest::{Harness, kittest::Queryable as _};
+
+use egui_tiles::{
+    Behavior, Container, ContainerKind, EditAction, Tile, TileId, Tiles, Tree, UiResponse,
+};
+
+// ----------------------------------------------------------------------------
+// The app's own source of truth — analogous to Rerun's blueprint.
+
+/// A node in the app's own layout model, identified by a stable string id.
+#[derive(Clone)]
+enum Node {
+    Pane {
+        id: String,
+    },
+    Container {
+        id: String,
+        kind: ContainerKind,
+        children: Vec<Self>,
+    },
+}
+
+impl Node {
+    fn pane(id: impl Into<String>) -> Self {
+        Self::Pane { id: id.into() }
+    }
+
+    fn container(id: impl Into<String>, kind: ContainerKind, children: Vec<Self>) -> Self {
+        Self::Container {
+            id: id.into(),
+            kind,
+            children,
+        }
+    }
+
+    /// The panes this layout holds, sorted — the order changes as tiles get rearranged,
+    /// but the set of panes must not.
+    fn sorted_pane_ids(&self) -> Vec<&str> {
+        fn collect<'a>(node: &'a Node, out: &mut Vec<&'a str>) {
+            match node {
+                Node::Pane { id } => out.push(id.as_str()),
+                Node::Container { children, .. } => {
+                    for child in children {
+                        collect(child, out);
+                    }
+                }
+            }
+        }
+
+        let mut ids = Vec::new();
+        collect(self, &mut ids);
+        ids.sort_unstable();
+        ids
+    }
+
+    /// A compact rendering of the layout, for assertion messages.
+    fn describe(&self) -> String {
+        match self {
+            Self::Pane { id } => id.clone(),
+            Self::Container { kind, children, .. } => format!(
+                "{kind:?}[{}]",
+                children
+                    .iter()
+                    .map(Self::describe)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        }
+    }
+}
+
+/// Everything that has to survive from one frame to the next. Notably *not* the [`Tree`].
+#[derive(Default)]
+struct App {
+    blueprint: Blueprint,
+    behavior: TestBehavior,
+}
+
+struct Blueprint {
+    root: Node,
+    /// Monotonic source of fresh ids for containers the tree grew that we've never seen.
+    next_generated_id: u64,
+}
+
+impl Default for Blueprint {
+    fn default() -> Self {
+        // Nested containers of three different kinds, so the drops below land in meaningfully
+        // different places:
+        //
+        //   Horizontal[ pane_a, Vertical[ pane_b, Tabs[ pane_c, pane_d ] ] ]
+        Self {
+            root: Node::container(
+                "root",
+                ContainerKind::Horizontal,
+                vec![
+                    Node::pane("pane_a"),
+                    Node::container(
+                        "right_column",
+                        ContainerKind::Vertical,
+                        vec![
+                            Node::pane("pane_b"),
+                            Node::container(
+                                "bottom_tabs",
+                                ContainerKind::Tabs,
+                                vec![Node::pane("pane_c"), Node::pane("pane_d")],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            next_generated_id: 0,
+        }
+    }
+}
+
+/// Stable [`TileId`] from an app id — deterministic, so re-creating the tree yields the same ids.
+fn tile_id(app_id: &str) -> TileId {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    app_id.hash(&mut hasher);
+    TileId::from_u64(hasher.finish())
+}
+
+impl Blueprint {
+    /// Build a fresh [`Tree`] from the blueprint, plus a `TileId -> app id` reverse map.
+    fn to_tree(&self) -> (Tree<String>, HashMap<TileId, String>) {
+        fn insert(
+            node: &Node,
+            tiles: &mut Tiles<String>,
+            reverse: &mut HashMap<TileId, String>,
+        ) -> TileId {
+            match node {
+                Node::Pane { id } => {
+                    let tile = tile_id(id);
+                    tiles.insert(tile, Tile::Pane(id.clone()));
+                    reverse.insert(tile, id.clone());
+                    tile
+                }
+                Node::Container { id, kind, children } => {
+                    let child_ids = children.iter().map(|c| insert(c, tiles, reverse)).collect();
+                    let tile = tile_id(id);
+                    tiles.insert(tile, Tile::Container(Container::new(*kind, child_ids)));
+                    reverse.insert(tile, id.clone());
+                    tile
+                }
+            }
+        }
+
+        let mut tiles = Tiles::default();
+        let mut reverse = HashMap::new();
+        let root = insert(&self.root, &mut tiles, &mut reverse);
+        (Tree::new("test_tree", root, tiles), reverse)
+    }
+
+    /// Fold an edited tree back into the blueprint, minting fresh ids for any newly-created
+    /// containers — exactly what the app does after a drop.
+    fn sync_from_tree(&mut self, tree: &Tree<String>, reverse: &HashMap<TileId, String>) {
+        fn rebuild(
+            tile_id: TileId,
+            tree: &Tree<String>,
+            reverse: &HashMap<TileId, String>,
+            next: &mut u64,
+        ) -> Option<Node> {
+            match tree.tiles.get(tile_id)? {
+                Tile::Pane(app_id) => Some(Node::pane(app_id.clone())),
+                Tile::Container(container) => {
+                    let id = reverse.get(&tile_id).cloned().unwrap_or_else(|| {
+                        let generated = format!("generated_container_{next}");
+                        *next += 1;
+                        generated
+                    });
+                    let children = container
+                        .children()
+                        .filter_map(|&c| rebuild(c, tree, reverse, next))
+                        .collect();
+                    Some(Node::container(id, container.kind(), children))
+                }
+            }
+        }
+
+        if let Some(root) = tree.root
+            && let Some(node) = rebuild(root, tree, reverse, &mut self.next_generated_id)
+        {
+            self.root = node;
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+/// Counts the drops `egui_tiles` actually committed, so the assertions below can tell a
+/// successful drag from one that quietly did nothing.
+#[derive(Default)]
+struct TestBehavior {
+    tiles_dropped: usize,
+}
+
+/// The accessibility label of the drag handle inside a pane, used to find it from the test.
+fn drag_handle_label(pane: &str) -> String {
+    format!("drag {pane}")
+}
+
+impl Behavior<String> for TestBehavior {
+    fn on_edit(&mut self, action: EditAction) {
+        if action == EditAction::TileDropped {
+            self.tiles_dropped += 1;
+        }
+    }
+
+    fn tab_title_for_pane(&mut self, pane: &String) -> egui::WidgetText {
+        pane.clone().into()
+    }
+
+    fn pane_ui(&mut self, ui: &mut egui::Ui, _tile_id: TileId, pane: &mut String) -> UiResponse {
+        let handle = egui::Button::new(drag_handle_label(pane)).sense(egui::Sense::drag());
+        if ui.add(handle).drag_started() {
+            UiResponse::DragStarted
+        } else {
+            UiResponse::None
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+/// Dragging a pane and dropping it must never lose a pane, however the tree gets rearranged.
+///
+/// The drag is driven through the real widgets — press the pane's drag handle, move the pointer,
+/// release — rather than by poking `egui_tiles` internals, so this exercises the same path a user
+/// would take.
+#[test]
+fn dropping_a_pane_never_loses_it() {
+    const PANES: &str = "pane_a, pane_b, pane_c, pane_d";
+
+    // Where to drop `pane_a`, named by the widget to aim the pointer at. Each lands somewhere
+    // structurally different: a pane in a sibling container, a tab bar, and an open tab.
+    let targets = [
+        ("onto pane_b", drag_handle_label("pane_b")),
+        ("onto the tab bar", "pane_d".to_owned()),
+        ("into the open tab", drag_handle_label("pane_c")),
+    ];
+
+    for (what, target_label) in targets {
+        let mut harness = Harness::builder()
+            .with_size(egui::vec2(900.0, 600.0))
+            .build_ui_state(
+                |ui, app: &mut App| {
+                    // Re-create the tree from the app's own model every frame:
+                    let (mut tree, reverse) = app.blueprint.to_tree();
+                    tree.ui(&mut app.behavior, ui);
+                    // Persist any edit back, so it survives the next rebuild:
+                    app.blueprint.sync_from_tree(&tree, &reverse);
+                },
+                App::default(),
+            );
+
+        harness.run();
+
+        let layout_before = harness.state().blueprint.root.describe();
+        assert_eq!(
+            harness.state().blueprint.root.sorted_pane_ids().join(", "),
+            PANES,
+            "sanity: four panes to begin with, but the layout is {layout_before}"
+        );
+
+        let from = harness.get_by_label(&drag_handle_label("pane_a")).rect();
+        let to = harness.get_by_label(&target_label).rect();
+
+        // Press the pane's drag handle, move onto the target, hold, release:
+        harness.drag_at(from.center());
+        harness.step();
+        harness.hover_at(to.center());
+        for _ in 0..4 {
+            harness.step();
+        }
+        harness.drop_at(to.center());
+        harness.step();
+        harness.run();
+
+        let app = harness.state();
+        let layout_after = app.blueprint.root.describe();
+
+        assert_eq!(
+            app.blueprint.root.sorted_pane_ids().join(", "),
+            PANES,
+            "a pane went missing dropping {what}: {layout_before} -> {layout_after}"
+        );
+
+        // Otherwise the check above could pass simply because the drag never happened.
+        // Note that a committed drop can still leave the *shape* unchanged -- dropping onto the
+        // tab bar wraps the column in a new container that simplification then unwraps again --
+        // so count the drops rather than comparing layouts.
+        assert_eq!(
+            app.behavior.tiles_dropped, 1,
+            "expected exactly one committed drop when dropping {what}"
+        );
+    }
+}

--- a/tests/tree_recreated_every_frame.rs
+++ b/tests/tree_recreated_every_frame.rs
@@ -148,7 +148,7 @@ impl Blueprint {
                 Node::Pane { id } => {
                     let tile = tile_id(id);
                     tiles.insert(tile, Tile::Pane(id.clone()));
-                    reverse.insert(tile, id.clone());
+                    // Deliberately NOT in `reverse`; see the note on `sync_from_tree`.
                     tile
                 }
                 Node::Container { id, kind, children } => {
@@ -169,6 +169,13 @@ impl Blueprint {
 
     /// Fold an edited tree back into the blueprint, minting fresh ids for any newly-created
     /// containers — exactly what the app does after a drop.
+    ///
+    /// `reverse` deliberately holds **containers only**: a `TileId` does not keep referring to
+    /// the same kind of tile. Dropping a pane onto another pane makes `egui_tiles` reuse the
+    /// target's id for the container it wraps them in, so an id that meant `"pane_a"` one frame
+    /// means `"the container holding pane_a"` the next. Handing that container the app id
+    /// `"pane_a"` would make the next `to_tree()` insert a pane and a container at the same id,
+    /// silently losing a pane. See `examples/tree_recreated_every_frame.rs`.
     fn sync_from_tree(&mut self, tree: &Tree<String>, reverse: &HashMap<TileId, String>) {
         fn rebuild(
             tile_id: TileId,
@@ -243,71 +250,155 @@ impl Behavior<String> for TestBehavior {
 /// The drag is driven through the real widgets — press the pane's drag handle, move the pointer,
 /// release — rather than by poking `egui_tiles` internals, so this exercises the same path a user
 /// would take.
+/// Build a harness around a fresh app.
+fn harness() -> egui_kittest::Harness<'static, App> {
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(900.0, 600.0))
+        .build_ui_state(
+            |ui, app: &mut App| {
+                // Re-create the tree from the app's own model every frame:
+                let (mut tree, reverse) = app.blueprint.to_tree();
+                tree.ui(&mut app.behavior, ui);
+                // Persist any edit back, so it survives the next rebuild:
+                app.blueprint.sync_from_tree(&tree, &reverse);
+            },
+            App::default(),
+        );
+    harness.run();
+    harness
+}
+
+/// Drag the pane named `source` onto whatever widget is labelled `target_label`, and let go.
+///
+/// The drag goes through the real widgets — find the pane's drag handle by its accessibility
+/// label, press it, move the pointer, release — rather than by poking `egui_tiles` internals, so
+/// this exercises the path a user actually takes. Returns `false` if either widget is not on
+/// screen (an inactive tab's contents, say).
+fn drag_pane_onto(
+    harness: &mut egui_kittest::Harness<'_, App>,
+    source: &str,
+    target_label: &str,
+) -> bool {
+    let Some(from) = harness
+        .query_by_label(&drag_handle_label(source))
+        .map(|node| node.rect())
+    else {
+        return false;
+    };
+    let Some(to) = harness.query_by_label(target_label).map(|node| node.rect()) else {
+        return false;
+    };
+
+    harness.drag_at(from.center());
+    harness.step();
+    harness.hover_at(to.center());
+    // The drop zone is only settled once the tile has been hovered for a frame or two.
+    for _ in 0..4 {
+        harness.step();
+    }
+    harness.drop_at(to.center());
+    harness.step();
+    harness.run();
+
+    true
+}
+
+const PANES: [&str; 4] = ["pane_a", "pane_b", "pane_c", "pane_d"];
+
+fn all_panes() -> String {
+    PANES.join(", ")
+}
+
+/// Every way of dropping one pane onto another must leave all four panes in place.
+///
+/// Dropping *onto* a pane is the interesting case: `egui_tiles` reuses the target's `TileId` for
+/// the container it wraps them both in, which is exactly the sharp edge documented on
+/// `Blueprint::sync_from_tree`.
 #[test]
 fn dropping_a_pane_never_loses_it() {
-    const PANES: &str = "pane_a, pane_b, pane_c, pane_d";
+    let mut dragged = 0;
+    let mut skipped = 0;
 
-    // Where to drop `pane_a`, named by the widget to aim the pointer at. Each lands somewhere
-    // structurally different: a pane in a sibling container, a tab bar, and an open tab.
-    let targets = [
-        ("onto pane_b", drag_handle_label("pane_b")),
-        ("onto the tab bar", "pane_d".to_owned()),
-        ("into the open tab", drag_handle_label("pane_c")),
-    ];
+    for source in PANES {
+        for target in PANES {
+            if source == target {
+                continue;
+            }
 
-    for (what, target_label) in targets {
-        let mut harness = Harness::builder()
-            .with_size(egui::vec2(900.0, 600.0))
-            .build_ui_state(
-                |ui, app: &mut App| {
-                    // Re-create the tree from the app's own model every frame:
-                    let (mut tree, reverse) = app.blueprint.to_tree();
-                    tree.ui(&mut app.behavior, ui);
-                    // Persist any edit back, so it survives the next rebuild:
-                    app.blueprint.sync_from_tree(&tree, &reverse);
-                },
-                App::default(),
-            );
+            // Aim both at the pane itself, and at its tab in a tab bar (when it has one).
+            for target_label in [drag_handle_label(target), target.to_owned()] {
+                let mut harness = harness();
+                let before = harness.state().blueprint.root.describe();
 
-        harness.run();
+                if !drag_pane_onto(&mut harness, source, &target_label) {
+                    // The target is not on screen — an inactive tab's contents, say.
+                    skipped += 1;
+                    continue;
+                }
+                dragged += 1;
 
-        let layout_before = harness.state().blueprint.root.describe();
-        assert_eq!(
-            harness.state().blueprint.root.sorted_pane_ids().join(", "),
-            PANES,
-            "sanity: four panes to begin with, but the layout is {layout_before}"
-        );
+                let app = harness.state();
 
-        let from = harness.get_by_label(&drag_handle_label("pane_a")).rect();
-        let to = harness.get_by_label(&target_label).rect();
+                assert_eq!(
+                    app.blueprint.root.sorted_pane_ids().join(", "),
+                    all_panes(),
+                    "dragging {source} onto {target_label} lost a pane: {before} -> {}",
+                    app.blueprint.root.describe()
+                );
 
-        // Press the pane's drag handle, move onto the target, hold, release:
-        harness.drag_at(from.center());
-        harness.step();
-        harness.hover_at(to.center());
-        for _ in 0..4 {
-            harness.step();
+                // Otherwise the check above would pass by never having dragged anything.
+                assert_eq!(
+                    app.behavior.tiles_dropped, 1,
+                    "dragging {source} onto {target_label} committed no drop"
+                );
+            }
         }
-        harness.drop_at(to.center());
-        harness.step();
-        harness.run();
-
-        let app = harness.state();
-        let layout_after = app.blueprint.root.describe();
-
-        assert_eq!(
-            app.blueprint.root.sorted_pane_ids().join(", "),
-            PANES,
-            "a pane went missing dropping {what}: {layout_before} -> {layout_after}"
-        );
-
-        // Otherwise the check above could pass simply because the drag never happened.
-        // Note that a committed drop can still leave the *shape* unchanged -- dropping onto the
-        // tab bar wraps the column in a new container that simplification then unwraps again --
-        // so count the drops rather than comparing layouts.
-        assert_eq!(
-            app.behavior.tiles_dropped, 1,
-            "expected exactly one committed drop when dropping {what}"
-        );
     }
+
+    assert!(
+        0 < dragged,
+        "no drag ran at all ({skipped} target(s) were off screen)"
+    );
+}
+
+/// The same, but on one long-lived app, so that whatever a drop leaves behind is carried into the
+/// next one. Losing a pane only on the fifth drag still loses a pane.
+#[test]
+fn many_drags_in_a_row_never_lose_a_pane() {
+    let mut harness = harness();
+    let mut drags = 0;
+    let mut dropped_before = 0;
+
+    for round in 0..PANES.len() {
+        for (i, source) in PANES.iter().enumerate() {
+            let target = PANES[(i + 1 + round) % PANES.len()];
+            if *source == target {
+                continue;
+            }
+
+            for target_label in [drag_handle_label(target), target.to_owned()] {
+                let before = harness.state().blueprint.root.describe();
+                if !drag_pane_onto(&mut harness, source, &target_label) {
+                    continue;
+                }
+                drags += 1;
+
+                let app = harness.state();
+                assert_eq!(
+                    app.blueprint.root.sorted_pane_ids().join(", "),
+                    all_panes(),
+                    "drag {drags} ({source} onto {target_label}) lost a pane: {before} -> {}",
+                    app.blueprint.root.describe()
+                );
+                assert_eq!(
+                    app.behavior.tiles_dropped,
+                    dropped_before + 1,
+                    "drag {drags} ({source} onto {target_label}) committed no drop"
+                );
+                dropped_before = app.behavior.tiles_dropped;
+            }
+        }
+    }
+
+    assert!(0 < drags, "no drag ran at all");
 }


### PR DESCRIPTION
Extracted from #139. Example + test only, no library changes.

Stacked on #143. Read [this PR's own commits](https://github.com/rerun-io/egui_tiles/pull/142/commits) for just the new material.

### Why

Rerun (and apps like it) don't treat the `Tree` as the source of truth. They keep their own layout model, build a fresh `Tree` from it every frame with `TileId`s derived from their own stable ids, and fold any edit back out of the tree afterwards.

That puts constraints on `egui_tiles` that none of the existing examples show, and they are easy to get wrong in ways that silently lose a pane rather than failing to compile.

### What

**`examples/tree_recreated_every_frame.rs`** — a runnable app in that shape, with a live pane counter in the top bar that must not change while you drag things around:

```
Horizontal[ pane_a, Vertical[ pane_b, Tabs[ pane_c, pane_d ] ] ]
```

**`tests/tree_recreated_every_frame.rs`** — the same setup driven headlessly by `egui_kittest`, covering every way of dropping one pane onto another (aiming both at the pane and at its tab), both on a fresh tree and on one long-lived app where each drop's leftovers feed into the next.

### A sharp edge this turned up

The first version of the example lost the pane you dropped *onto*:

```
Horizontal[pane_a, Vertical[pane_b, Tabs[pane_c, pane_d]]]
-> Horizontal[pane_b, Tabs[pane_c, pane_d]]        # pane_a gone
```

**A `TileId` does not keep referring to the same kind of tile.** When you drop onto a pane, `Tiles::insert_at` reuses the *target's* id for the new container it wraps them both in, and moves the target pane itself to a freshly allocated id. So an id that meant `"pane_a"` one frame means "the container holding `pane_a`" the next.

The example was putting panes in its `TileId -> app id` map, so that new container got handed the app id `"pane_a"`, and the next `to_tree()` inserted both a pane and a container at `tile_id("pane_a")` — the second overwriting the first.

Panes carry their app id as their payload and never needed to be in that map. Now only containers are, and this is written up on `Blueprint::sync_from_tree`, since anyone driving `egui_tiles` this way can hit it.

Arguably `egui_tiles` should not reuse the target's id like this — see the follow-up noted at the bottom of #139. That is a breaking change to tile identity across a drop, so it wants its own PR; this one just makes the example correct and documents the trap.

### Notes on the tests

* The drag goes through the **real widgets** — find the pane's drag handle by its accessibility label, press it, move the pointer, release — so it exercises the path a user takes and needs nothing beyond the public API. Finding a *tab* by name is what #143 makes possible.
* Each drag asserts that a drop really was committed, so a pane-count check can never pass by quietly doing nothing. Verified by aiming a drag at empty space: `committed no drop`.
* Skipped targets (an inactive tab's contents, say) are counted rather than silently ignored.

### Testing

`cargo fmt --check`, `cargo clippy --all-features --all-targets`, `cargo test --all-features` all clean. Adds `egui_kittest` as a dev-dependency.

The example builds; I have **not** run it in a window, so the drag *feel* is unverified — but the pane-loss bug you hit is now covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
