### PR TITLE
Report tabs to accessibility tools

### DIFF
--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -1,6 +1,6 @@
 use egui::{
-    Color32, Id, Rect, Response, Rgba, Sense, Stroke, TextStyle, Ui, Vec2, Visuals, WidgetText,
-    vec2,
+    Color32, Id, Rect, Response, Rgba, Sense, Stroke, TextStyle, Ui, Vec2, Visuals, WidgetInfo,
+    WidgetText, WidgetType, vec2,
 };
 
 use super::{ResizeState, SimplificationOptions, Tile, TileId, Tiles, UiResponse};
@@ -182,6 +182,20 @@ pub trait Behavior<Pane> {
             tab_response
         };
 
+        // A bare `Ui::interact` reports nothing about itself, so without this a tab is an unnamed
+        // blob to screen readers, and cannot be found by name from `egui_kittest`.
+        //
+        // Deliberately outside the `is_rect_visible` check below: a tab scrolled out of the tab
+        // bar is still a tab.
+        tab_response.widget_info(|| {
+            WidgetInfo::selected(
+                WidgetType::Button,
+                ui.is_enabled(),
+                state.active,
+                galley.text(),
+            )
+        });
+
         // Show a gap when dragged
         if ui.is_rect_visible(tab_rect) && !state.is_being_dragged {
             let bg_color = self.tab_bg_color(ui.visuals(), tiles, tile_id, state);
@@ -222,6 +236,10 @@ pub trait Behavior<Pane> {
                 let close_btn_response = ui
                     .interact(close_btn_rect, close_btn_id, Sense::click_and_drag())
                     .on_hover_cursor(egui::CursorIcon::Default);
+
+                close_btn_response.widget_info(|| {
+                    WidgetInfo::labeled(WidgetType::Button, ui.is_enabled(), "Close")
+                });
 
                 let visuals = ui.style().interact(&close_btn_response);
 


### PR DESCRIPTION
The default `Behavior::tab_ui` draws a tab with a bare `Ui::interact` plus manual painting. `Ui::interact` reports nothing about itself, so a tab currently has **no accessibility information at all** — a screen reader sees an unnamed, untyped blob where a tab should be, with no way to tell which one is selected.

This reports it as a button carrying the tab's title and its selected state:

```rust
tab_response.widget_info(|| {
    WidgetInfo::selected(WidgetType::Button, ui.is_enabled(), state.active, galley.text())
});
```

The close button gets a `"Close"` label the same way.

Deliberately outside the `is_rect_visible` check: a tab scrolled out of the tab bar is still a tab, and should still be announced.

Anyone who overrides `tab_ui` is unaffected — they were already responsible for their own widget info.

### It also unlocks a whole category of test

Tabs were previously unreachable by name from `egui_kittest`, so `harness.get_by_label("my tab")` found nothing. A test could only grab a pane by the drag handle *inside* it — and that handle only exists when the pane is the open tab.

So in `tests/tree_recreated_every_frame.rs` (added in #145), `pane_d` could never be the source of a drag: a quarter of the tree was untouchable. With tab labels, a pane can be dragged by its tab instead. The drag sweep now tries both grab points on both ends of every drag:

| | committed drops | with a non-open tab as source |
|---|---|---|
| before | 6 | 0 |
| after | 18 | 4 |

I measured both numbers by reverting just `src/behavior.rs` to `main` and re-running, so that is the actual delta from this change rather than an estimate.

The test also gets a little simpler: `drag_onto` now takes two labels instead of a pane name and a label, so both ends of a drag are described the same way.

### Testing

`cargo fmt --check`, `cargo clippy --all-features --all-targets` and `cargo test --all-features` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
