### PR TITLE
Keep a tile's TileId when it gets wrapped in a container

### DIFF
--- a/src/container/grid.rs
+++ b/src/container/grid.rs
@@ -111,6 +111,17 @@ impl Grid {
 
     /// Returns the child already at the given index, if any.
     #[must_use]
+    /// Swap out one child for another, keeping its cell.
+    ///
+    /// The column and row shares are positional, so they need no fixing up.
+    pub(super) fn replace_child(&mut self, old: TileId, new: TileId) -> bool {
+        let Some(slot) = self.children.iter_mut().find(|child| **child == Some(old)) else {
+            return false;
+        };
+        *slot = Some(new);
+        true
+    }
+
     pub fn replace_at(&mut self, index: usize, child: TileId) -> Option<TileId> {
         if let Some(slot) = self.children.get_mut(index) {
             slot.replace(child)

--- a/src/container/grid.rs
+++ b/src/container/grid.rs
@@ -111,17 +111,6 @@ impl Grid {
 
     /// Returns the child already at the given index, if any.
     #[must_use]
-    /// Swap out one child for another, keeping its cell.
-    ///
-    /// The column and row shares are positional, so they need no fixing up.
-    pub(super) fn replace_child(&mut self, old: TileId, new: TileId) -> bool {
-        let Some(slot) = self.children.iter_mut().find(|child| **child == Some(old)) else {
-            return false;
-        };
-        *slot = Some(new);
-        true
-    }
-
     pub fn replace_at(&mut self, index: usize, child: TileId) -> Option<TileId> {
         if let Some(slot) = self.children.get_mut(index) {
             slot.replace(child)
@@ -130,6 +119,19 @@ impl Grid {
             self.children.push(Some(child));
             None
         }
+    }
+
+    /// Swap out one child for another, keeping its cell.
+    ///
+    /// The column and row shares are positional, so they need no fixing up.
+    ///
+    /// Returns the index of the cell that was swapped,
+    /// or `None` if `old` was not a child of this grid.
+    #[must_use]
+    pub(super) fn replace_child(&mut self, old: TileId, new: TileId) -> Option<usize> {
+        let index = self.children.iter().position(|child| *child == Some(old))?;
+        self.children[index] = Some(new);
+        Some(index)
     }
 
     fn collapse_holes(&mut self) {

--- a/src/container/linear.rs
+++ b/src/container/linear.rs
@@ -145,13 +145,15 @@ impl Linear {
     }
 
     /// Swap out one child for another, keeping its position and its share of the space.
-    pub(super) fn replace_child(&mut self, old: TileId, new: TileId) -> bool {
-        let Some(slot) = self.children.iter_mut().find(|child| **child == old) else {
-            return false;
-        };
-        *slot = new;
+    ///
+    /// Returns the index of the child that was swapped,
+    /// or `None` if `old` was not a child of this container.
+    #[must_use]
+    pub(super) fn replace_child(&mut self, old: TileId, new: TileId) -> Option<usize> {
+        let index = self.children.iter().position(|child| *child == old)?;
+        self.children[index] = new;
         self.shares.replace_with(old, new);
-        true
+        Some(index)
     }
 
     pub fn add_child(&mut self, child: TileId) {

--- a/src/container/linear.rs
+++ b/src/container/linear.rs
@@ -144,6 +144,16 @@ impl Linear {
         slf
     }
 
+    /// Swap out one child for another, keeping its position and its share of the space.
+    pub(super) fn replace_child(&mut self, old: TileId, new: TileId) -> bool {
+        let Some(slot) = self.children.iter_mut().find(|child| **child == old) else {
+            return false;
+        };
+        *slot = new;
+        self.shares.replace_with(old, new);
+        true
+    }
+
     pub fn add_child(&mut self, child: TileId) {
         self.children.push(child);
     }

--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -178,8 +178,10 @@ impl Container {
 
     /// Swap out one child for another, keeping its place and its share of the space.
     ///
-    /// Returns `false` if `old` was not a child of this container.
-    pub fn replace_child(&mut self, old: TileId, new: TileId) -> bool {
+    /// Returns the child index that was swapped, mirroring [`Self::remove_child`],
+    /// or `None` if `old` was not a child of this container.
+    #[must_use]
+    pub fn replace_child(&mut self, old: TileId, new: TileId) -> Option<usize> {
         match self {
             Self::Tabs(tabs) => tabs.replace_child(old, new),
             Self::Linear(linear) => linear.replace_child(old, new),

--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -176,6 +176,17 @@ impl Container {
         }
     }
 
+    /// Swap out one child for another, keeping its place and its share of the space.
+    ///
+    /// Returns `false` if `old` was not a child of this container.
+    pub fn replace_child(&mut self, old: TileId, new: TileId) -> bool {
+        match self {
+            Self::Tabs(tabs) => tabs.replace_child(old, new),
+            Self::Linear(linear) => linear.replace_child(old, new),
+            Self::Grid(grid) => grid.replace_child(old, new),
+        }
+    }
+
     /// Returns child index, if found.
     pub fn remove_child(&mut self, child: TileId) -> Option<usize> {
         match self {

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -152,6 +152,18 @@ impl Tabs {
         self.children.push(child);
     }
 
+    /// Swap out one tab for another, keeping its position and whether it was the open one.
+    pub(super) fn replace_child(&mut self, old: TileId, new: TileId) -> bool {
+        let Some(slot) = self.children.iter_mut().find(|child| **child == old) else {
+            return false;
+        };
+        *slot = new;
+        if self.active == Some(old) {
+            self.active = Some(new);
+        }
+        true
+    }
+
     pub fn set_active(&mut self, child: TileId) {
         self.active = Some(child);
     }

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -153,15 +153,17 @@ impl Tabs {
     }
 
     /// Swap out one tab for another, keeping its position and whether it was the open one.
-    pub(super) fn replace_child(&mut self, old: TileId, new: TileId) -> bool {
-        let Some(slot) = self.children.iter_mut().find(|child| **child == old) else {
-            return false;
-        };
-        *slot = new;
+    ///
+    /// Returns the index of the tab that was swapped,
+    /// or `None` if `old` was not a tab of this container.
+    #[must_use]
+    pub(super) fn replace_child(&mut self, old: TileId, new: TileId) -> Option<usize> {
+        let index = self.children.iter().position(|child| *child == old)?;
+        self.children[index] = new;
         if self.active == Some(old) {
             self.active = Some(new);
         }
-        true
+        Some(index)
     }
 
     pub fn set_active(&mut self, child: TileId) {

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -3,7 +3,7 @@ use egui::{Pos2, Rect};
 use crate::behavior::LayoutContext;
 
 use super::{
-    Behavior, Container, ContainerInsertion, ContainerKind, GcAction, Grid, InsertionPoint, Linear,
+    Behavior, Container, ContainerInsertion, ContainerKind, GcAction, InsertionPoint, Linear,
     LinearDir, SimplificationOptions, SimplifyAction, Tabs, Tile, TileId,
 };
 
@@ -276,7 +276,23 @@ impl<Pane> Tiles<Pane> {
         self.parent_of(tile_id).is_none()
     }
 
-    pub(super) fn insert_at(&mut self, insertion_point: InsertionPoint, inserted_id: TileId) {
+    /// Insert `inserted_id` into the tree at `insertion_point`.
+    ///
+    /// When the insertion point's parent is not already a container of the required kind, that
+    /// parent gets wrapped in a new container holding both it and `inserted_id`. The parent keeps
+    /// its own [`TileId`] and the *new* container is the one given a freshly allocated id, so a
+    /// `TileId` always keeps referring to the same tile. Applications that key their own state off
+    /// `TileId`s depend on that.
+    ///
+    /// Returns the id of the new container, when one was needed. Since [`Tiles`] does not know
+    /// what the tree's root is, the caller must re-point the root at it if the wrapped tile
+    /// happened to be the root.
+    #[must_use]
+    pub(super) fn insert_at(
+        &mut self,
+        insertion_point: InsertionPoint,
+        inserted_id: TileId,
+    ) -> Option<TileId> {
         let InsertionPoint {
             parent_id,
             insertion,
@@ -284,73 +300,85 @@ impl<Pane> Tiles<Pane> {
 
         let Some(mut parent_tile) = self.tiles.remove(&parent_id) else {
             log::debug!("Failed to insert: could not find parent {parent_id:?}");
-            return;
+            return None;
         };
 
-        match insertion {
-            ContainerInsertion::Tabs(index) => {
-                if let Tile::Container(Container::Tabs(tabs)) = &mut parent_tile {
-                    let index = index.min(tabs.children.len());
-                    tabs.children.insert(index, inserted_id);
-                    tabs.set_active(inserted_id);
-                    self.tiles.insert(parent_id, parent_tile);
-                } else {
-                    let new_tile_id = self.insert_new(parent_tile);
-                    let mut tabs = Tabs::new(vec![new_tile_id]);
-                    tabs.children.insert(index.min(1), inserted_id);
-                    tabs.set_active(inserted_id);
-                    self.tiles
-                        .insert(parent_id, Tile::Container(Container::Tabs(tabs)));
-                }
+        // Can the parent take the tile as-is, or does it need wrapping in a new container?
+        let inserted_into_parent = match (&mut parent_tile, insertion) {
+            (Tile::Container(Container::Tabs(tabs)), ContainerInsertion::Tabs(index)) => {
+                let index = index.min(tabs.children.len());
+                tabs.children.insert(index, inserted_id);
+                tabs.set_active(inserted_id);
+                true
             }
-            ContainerInsertion::Horizontal(index) => {
-                if let Tile::Container(Container::Linear(Linear {
-                    dir: LinearDir::Horizontal,
-                    children,
-                    ..
-                })) = &mut parent_tile
-                {
-                    let index = index.min(children.len());
-                    children.insert(index, inserted_id);
-                    self.tiles.insert(parent_id, parent_tile);
-                } else {
-                    let new_tile_id = self.insert_new(parent_tile);
-                    let mut linear = Linear::new(LinearDir::Horizontal, vec![new_tile_id]);
-                    linear.children.insert(index.min(1), inserted_id);
-                    self.tiles
-                        .insert(parent_id, Tile::Container(Container::Linear(linear)));
-                }
+
+            (
+                Tile::Container(Container::Linear(
+                    linear @ Linear {
+                        dir: LinearDir::Horizontal,
+                        ..
+                    },
+                )),
+                ContainerInsertion::Horizontal(index),
+            )
+            | (
+                Tile::Container(Container::Linear(
+                    linear @ Linear {
+                        dir: LinearDir::Vertical,
+                        ..
+                    },
+                )),
+                ContainerInsertion::Vertical(index),
+            ) => {
+                let index = index.min(linear.children.len());
+                linear.children.insert(index, inserted_id);
+                true
             }
-            ContainerInsertion::Vertical(index) => {
-                if let Tile::Container(Container::Linear(Linear {
-                    dir: LinearDir::Vertical,
-                    children,
-                    ..
-                })) = &mut parent_tile
-                {
-                    let index = index.min(children.len());
-                    children.insert(index, inserted_id);
-                    self.tiles.insert(parent_id, parent_tile);
-                } else {
-                    let new_tile_id = self.insert_new(parent_tile);
-                    let mut linear = Linear::new(LinearDir::Vertical, vec![new_tile_id]);
-                    linear.children.insert(index.min(1), inserted_id);
-                    self.tiles
-                        .insert(parent_id, Tile::Container(Container::Linear(linear)));
-                }
+
+            (Tile::Container(Container::Grid(grid)), ContainerInsertion::Grid(index)) => {
+                grid.insert_at(index, inserted_id);
+                true
             }
-            ContainerInsertion::Grid(index) => {
-                if let Tile::Container(Container::Grid(grid)) = &mut parent_tile {
-                    grid.insert_at(index, inserted_id);
-                    self.tiles.insert(parent_id, parent_tile);
-                } else {
-                    let new_tile_id = self.insert_new(parent_tile);
-                    let grid = Grid::new(vec![new_tile_id, inserted_id]);
-                    self.tiles
-                        .insert(parent_id, Tile::Container(Container::Grid(grid)));
-                }
-            }
+
+            _ => false,
+        };
+
+        // Either way the parent goes back exactly where it was, under its original id.
+        self.tiles.insert(parent_id, parent_tile);
+
+        if inserted_into_parent {
+            return None;
         }
+
+        // Look up the grandparent _before_ creating the wrapper, or `parent_of` would find the
+        // wrapper itself.
+        let grandparent_id = self.parent_of(parent_id);
+
+        let mut children = vec![parent_id];
+        children.insert(insertion.index().min(1), inserted_id);
+
+        let container = match insertion {
+            ContainerInsertion::Tabs(_) => {
+                let mut tabs = Tabs::new(children);
+                tabs.set_active(inserted_id);
+                Container::Tabs(tabs)
+            }
+            ContainerInsertion::Horizontal(_) => {
+                Container::new_linear(LinearDir::Horizontal, children)
+            }
+            ContainerInsertion::Vertical(_) => Container::new_linear(LinearDir::Vertical, children),
+            ContainerInsertion::Grid(_) => Container::new_grid(children),
+        };
+        let wrapper_id = self.insert_new(Tile::Container(container));
+
+        // Whoever referred to the parent now refers to the container wrapping it.
+        if let Some(grandparent_id) = grandparent_id
+            && let Some(Tile::Container(grandparent)) = self.get_mut(grandparent_id)
+        {
+            grandparent.replace_child(parent_id, wrapper_id);
+        }
+
+        Some(wrapper_id)
     }
 
     /// Detect cycles, duplications, and other invalid state, and fix it.
@@ -624,5 +652,190 @@ impl<Pane: PartialEq> Tiles<Pane> {
                 }
             })
             .map(|(tile_id, _)| *tile_id)
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Grid, GridLayout, Shares};
+
+    fn insertion(parent_id: TileId, insertion: ContainerInsertion) -> InsertionPoint {
+        InsertionPoint {
+            parent_id,
+            insertion,
+        }
+    }
+
+    /// Wrapping a tile in a new container must not disturb the wrapped tile's own [`TileId`].
+    ///
+    /// Applications may key their own state off `TileId`s (Rerun does), so an id has to keep
+    /// referring to the same tile for as long as that tile exists.
+    #[test]
+    fn wrapping_a_tile_keeps_its_id() {
+        for insertion_kind in [
+            ContainerInsertion::Tabs(1),
+            ContainerInsertion::Horizontal(1),
+            ContainerInsertion::Vertical(1),
+            ContainerInsertion::Grid(1),
+        ] {
+            let mut tiles = Tiles::default();
+            let a = tiles.insert_pane("a");
+            let b = tiles.insert_pane("b");
+            let root = tiles.insert_horizontal_tile(vec![a, b]);
+            let dropped = tiles.insert_pane("dropped");
+
+            // Drop `dropped` onto pane `a`, which has to wrap `a` in a new container:
+            let wrapper = tiles
+                .insert_at(insertion(a, insertion_kind), dropped)
+                .expect("wrapping a pane should have created a container");
+
+            assert_eq!(
+                tiles.get(a),
+                Some(&Tile::Pane("a")),
+                "{insertion_kind:?}: pane `a` must still be a pane, under its original id"
+            );
+            assert_ne!(
+                wrapper, a,
+                "{insertion_kind:?}: the new container needs its own id"
+            );
+
+            let wrapper_children = tiles
+                .get_container(wrapper)
+                .expect("the wrapper should be a container")
+                .children_vec();
+            assert!(
+                wrapper_children.contains(&a) && wrapper_children.contains(&dropped),
+                "{insertion_kind:?}: the wrapper should hold both tiles, but holds \
+                 {wrapper_children:?}"
+            );
+
+            // ...and the grandparent should now point at the wrapper rather than at `a`:
+            assert_eq!(
+                tiles
+                    .get_container(root)
+                    .expect("root should be a container")
+                    .children_vec(),
+                vec![wrapper, b],
+                "{insertion_kind:?}: the root should hold the wrapper in `a`'s old place"
+            );
+            assert_eq!(
+                tiles.parent_of(a),
+                Some(wrapper),
+                "{insertion_kind:?}: `a` should now live inside the wrapper"
+            );
+        }
+    }
+
+    /// The wrapper takes over the wrapped tile's place in the layout, so it must inherit its
+    /// share of the parent's space -- otherwise the layout jumps on drop.
+    #[test]
+    fn the_wrapper_inherits_the_wrapped_tile_s_share() {
+        let mut tiles = Tiles::default();
+        let a = tiles.insert_pane("a");
+        let b = tiles.insert_pane("b");
+        let root = tiles.insert_horizontal_tile(vec![a, b]);
+        let dropped = tiles.insert_pane("dropped");
+
+        // Give `a` a distinctly lopsided share:
+        let mut shares = Shares::default();
+        shares.set_share(a, 3.0);
+        shares.set_share(b, 1.0);
+        if let Some(Tile::Container(Container::Linear(linear))) = tiles.get_mut(root) {
+            linear.shares = shares;
+        }
+
+        let wrapper = tiles
+            .insert_at(insertion(a, ContainerInsertion::Vertical(1)), dropped)
+            .expect("wrapping a pane should have created a container");
+
+        let Some(Tile::Container(Container::Linear(linear))) = tiles.get(root) else {
+            panic!("root should still be a linear container");
+        };
+        assert_eq!(
+            linear.shares[wrapper], 3.0,
+            "the wrapper should have taken over `a`'s share"
+        );
+        assert_eq!(linear.shares[b], 1.0, "`b`'s share should be untouched");
+    }
+
+    /// If the wrapped tile was the open tab, the container replacing it should be the open tab.
+    #[test]
+    fn the_wrapper_inherits_being_the_active_tab() {
+        let mut tiles = Tiles::default();
+        let a = tiles.insert_pane("a");
+        let b = tiles.insert_pane("b");
+        let root = tiles.insert_tab_tile(vec![a, b]);
+        let dropped = tiles.insert_pane("dropped");
+
+        if let Some(Tile::Container(Container::Tabs(tabs))) = tiles.get_mut(root) {
+            tabs.set_active(a);
+        }
+
+        let wrapper = tiles
+            .insert_at(insertion(a, ContainerInsertion::Vertical(1)), dropped)
+            .expect("wrapping a pane should have created a container");
+
+        let Some(Tile::Container(Container::Tabs(tabs))) = tiles.get(root) else {
+            panic!("root should still be a tabs container");
+        };
+        assert_eq!(
+            tabs.active,
+            Some(wrapper),
+            "the wrapper took `a`'s place, so it should be the open tab"
+        );
+    }
+
+    /// A grid's shares are positional, so the wrapper has to land in the wrapped tile's cell.
+    #[test]
+    fn the_wrapper_takes_the_wrapped_tile_s_grid_cell() {
+        let mut tiles = Tiles::default();
+        let panes: Vec<TileId> = ["a", "b", "c", "d"]
+            .into_iter()
+            .map(|pane| tiles.insert_pane(pane))
+            .collect();
+        let mut grid = Grid::new(panes.clone());
+        grid.layout = GridLayout::Columns(2);
+        let root = tiles.insert_new(Tile::Container(Container::Grid(grid)));
+        let dropped = tiles.insert_pane("dropped");
+
+        // Wrap the third pane, i.e. the one in the bottom-left cell:
+        let wrapper = tiles
+            .insert_at(
+                insertion(panes[2], ContainerInsertion::Vertical(1)),
+                dropped,
+            )
+            .expect("wrapping a pane should have created a container");
+
+        assert_eq!(
+            tiles
+                .get_container(root)
+                .expect("root should be a container")
+                .children_vec(),
+            vec![panes[0], panes[1], wrapper, panes[3]],
+            "the wrapper should sit in the cell the wrapped pane occupied"
+        );
+    }
+
+    /// Inserting into a container that already accepts the tile must not wrap anything.
+    #[test]
+    fn inserting_into_a_matching_container_creates_nothing() {
+        let mut tiles = Tiles::default();
+        let a = tiles.insert_pane("a");
+        let root = tiles.insert_horizontal_tile(vec![a]);
+        let dropped = tiles.insert_pane("dropped");
+
+        let wrapper = tiles.insert_at(insertion(root, ContainerInsertion::Horizontal(0)), dropped);
+
+        assert_eq!(wrapper, None, "a horizontal container takes it directly");
+        assert_eq!(
+            tiles
+                .get_container(root)
+                .expect("root should be a container")
+                .children_vec(),
+            vec![dropped, a]
+        );
     }
 }

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -372,10 +372,16 @@ impl<Pane> Tiles<Pane> {
         let wrapper_id = self.insert_new(Tile::Container(container));
 
         // Whoever referred to the parent now refers to the container wrapping it.
+        // `grandparent_id` is `None` when the parent is the root, which the caller handles.
         if let Some(grandparent_id) = grandparent_id
             && let Some(Tile::Container(grandparent)) = self.get_mut(grandparent_id)
+            && grandparent.replace_child(parent_id, wrapper_id).is_none()
         {
-            grandparent.replace_child(parent_id, wrapper_id);
+            // `grandparent_id` came from `parent_of`, so this should be unreachable.
+            log::warn!(
+                "Bug: {grandparent_id:?} was the parent of {parent_id:?}, \
+                 but does not list it as a child"
+            );
         }
 
         Some(wrapper_id)

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -633,7 +633,7 @@ impl<Pane> Tree<Pane> {
                         }
                         Container::Grid(grid) => {
                             if reflow_grid {
-                                self.tiles.insert_at(insertion_point, moved_tile_id);
+                                self.insert_at(insertion_point, moved_tile_id);
                             } else {
                                 let dest_tile = grid.replace_at(dest_index, moved_tile_id);
                                 if let Some(dest) = dest_tile {
@@ -648,7 +648,17 @@ impl<Pane> Tree<Pane> {
         }
 
         // Moving to a new parent
-        self.tiles.insert_at(insertion_point, moved_tile_id);
+        self.insert_at(insertion_point, moved_tile_id);
+    }
+
+    /// [`Tiles::insert_at`], plus the root fix-up that only the [`Tree`] can do.
+    fn insert_at(&mut self, insertion_point: InsertionPoint, inserted_id: TileId) {
+        if let Some(wrapper_id) = self.tiles.insert_at(insertion_point, inserted_id)
+            && self.root == Some(insertion_point.parent_id)
+        {
+            // The root got wrapped in a new container, which is now the root.
+            self.root = Some(wrapper_id);
+        }
     }
 
     /// Find the currently dragged tile, if any.
@@ -752,4 +762,56 @@ fn smooth_preview_rect(ctx: &egui::Context, dragged_tile_id: TileId, new_rect: R
     }
 
     smoothed
+}
+
+// ----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ContainerInsertion;
+
+    /// Wrapping the root leaves the wrapped tile with its own id, so the _new_ container has to
+    /// become the root. Only the [`Tree`] knows what the root is, so [`Tiles`] hands it back.
+    #[test]
+    fn wrapping_the_root_makes_the_new_container_the_root() {
+        let mut tiles = Tiles::default();
+        let a = tiles.insert_pane("a");
+        let b = tiles.insert_pane("b");
+        let root = tiles.insert_horizontal_tile(vec![a, b]);
+        let dropped = tiles.insert_pane("dropped");
+        let mut tree = Tree::new("test", root, tiles);
+
+        // A vertical insertion into a horizontal container has to wrap it:
+        tree.move_tile(
+            dropped,
+            InsertionPoint {
+                parent_id: root,
+                insertion: ContainerInsertion::Vertical(1),
+            },
+            false,
+        );
+
+        let new_root = tree.root.expect("the tree should still have a root");
+        assert_ne!(
+            new_root, root,
+            "the wrapping container should be the new root"
+        );
+        assert_eq!(
+            tree.tiles
+                .get_container(root)
+                .expect("the old root should still be a container under its own id")
+                .children_vec(),
+            vec![a, b],
+            "the wrapped container should be untouched"
+        );
+        assert_eq!(
+            tree.tiles
+                .get_container(new_root)
+                .expect("the new root should be a container")
+                .children_vec(),
+            vec![root, dropped],
+        );
+        assert_eq!(tree.tiles.parent_of(root), Some(new_root));
+    }
 }


### PR DESCRIPTION
Dropping a tile onto another wraps them in a new container. That wrapper used to take over the **target's** `TileId`, moving the target to a fresh one:

```
drop X onto pane_a:
  before:  #7 = Pane("pane_a")
  after:   #7 = Linear[ #1, X ]     <-- #7 is a container now
           #1 = Pane("pane_a")      <-- the pane moved
```

So a `TileId` didn't keep referring to the same tile — a trap for apps that key their own state off `TileId`s, as Rerun does. Now the wrapped tile keeps its id and the new container gets the fresh one.

Since the wrapper takes over the wrapped tile's *place*, it inherits what that place carried: its share of a `Linear`'s space (`Shares` is keyed by `TileId`), its `Grid` cell, and whether it was the open tab. The grandparent is re-pointed at the wrapper; `Tiles` doesn't know the root, so `insert_at` returns the new id and `Tree` re-points the root when it was the root that got wrapped.

The four wrapping arms of `insert_at` collapse into one — they only differed in which container they built.

### Not fixed here

`make_all_panes_children_of_tabs` still takes over a pane's id for the tab container it wraps it in, so with `all_panes_must_have_tabs` a pane's id can still denote a container. Apps must still identify panes by payload, not tile id.

### ⚠️ Breaking

Container `TileId`s after a drop differ from before. Anything persisting a *container's* id across a drop sees different values. Panes are strictly better off.

For Rerun I read through `save_tree_as_containers` and believe this is a net **fix**: dropping onto a named container previously transferred that container's blueprint identity — and so its user-given name — to the new wrapper, leaving the original anonymous.

### Testing

Six unit tests: id preserved across all four insertion kinds, share/cell/active-tab inherited, no wrapper when the parent already accepts the tile, and the root case.

The convincing one: on top of the example on `main`, I restored the **naive** model-sync — the version that lost panes — and re-ran its full drag sweep. It passed, so the trap is gone rather than merely avoided. `test_grid_with_chaos_monkey` still passes too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
