### PR TITLE
Don't delete a shared tile during garbage collection

### DIFF
--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -429,6 +429,15 @@ impl<Pane> Tiles<Pane> {
         };
         if !visited.insert(tile_id) {
             log::warn!("Cycle or duplication detected");
+            // Put the tile back before telling the caller to drop it.
+            //
+            // What is duplicated is the *reference*, not the tile: we got here through a second
+            // parent, and the tile is still alive under the first one. Returning without the
+            // re-insert deletes it from the arena outright, and then the first parent names a
+            // child that no longer exists - damage strictly worse than the sharing it was meant
+            // to repair. `simplify` unravels it from there: the parent looks empty, gets pruned,
+            // its parent looks empty, and a tree that was merely ill-formed ends up gone.
+            self.tiles.insert(tile_id, tile);
             return GcAction::Remove;
         }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -816,4 +816,72 @@ mod tests {
         );
         assert_eq!(tree.tiles.parent_of(root), Some(new_root));
     }
+
+    /// Keeps every pane; `gc` needs a [`Behavior`], these tests are not about `retain_pane`.
+    struct KeepEverything;
+
+    impl Behavior<&'static str> for KeepEverything {
+        fn pane_ui(
+            &mut self,
+            _ui: &mut egui::Ui,
+            _tile_id: TileId,
+            _pane: &mut &'static str,
+        ) -> UiResponse {
+            UiResponse::None
+        }
+
+        fn tab_title_for_pane(&mut self, pane: &&'static str) -> egui::WidgetText {
+            (*pane).into()
+        }
+    }
+
+    /// A tile named as a child by two containers must lose the second *reference*, not itself.
+    ///
+    /// `gc` takes a tile out of the arena on the way in and puts it back on the way out, but the
+    /// early return for a tile it has already visited skips the putting back — so the tile is
+    /// deleted, while the container that legitimately owns it keeps naming it. `simplify` then
+    /// prunes that container as empty, and its parent, and the whole tree can disappear.
+    #[test]
+    fn gc_drops_the_second_reference_to_a_shared_tile_and_not_the_tile() {
+        let mut tiles = Tiles::default();
+        let pane = tiles.insert_pane("shared");
+        let first = tiles.insert_tab_tile(vec![pane]);
+        let second = tiles.insert_tab_tile(vec![pane]); // the same tile, a second parent
+        let root = tiles.insert_horizontal_tile(vec![first, second]);
+        let mut tree = Tree::new("shared", root, tiles);
+
+        tree.gc(&mut KeepEverything);
+
+        assert!(
+            tree.tiles.get(pane).is_some(),
+            "the shared tile itself must survive - only one of the two references is bogus"
+        );
+        assert_eq!(
+            tree.tiles
+                .get_container(first)
+                .expect("the first parent should still be a container")
+                .children_vec(),
+            vec![pane],
+            "the first parent to reach the tile keeps it"
+        );
+        assert!(
+            tree.tiles
+                .get_container(second)
+                .expect("the second parent should still be a container")
+                .children_vec()
+                .is_empty(),
+            "the second reference is the one that has to go"
+        );
+
+        // And the point of it all: the rest of the frame must not unravel the tree.
+        tree.simplify(&SimplificationOptions::default());
+        assert!(
+            tree.root.is_some(),
+            "the tree must still have a root after gc+simplify"
+        );
+        assert!(
+            tree.tiles.get(pane).is_some(),
+            "the pane must still be in the tree after gc+simplify"
+        );
+    }
 }


### PR DESCRIPTION
`Tiles::gc_tile_id` takes a tile out of the arena on the way in and puts it back on the way out. The early return for a tile it has already visited skips the putting back, so a tile that two containers name as a child is **deleted** — while the container that legitimately owns it keeps naming it.

What is duplicated there is the *reference*, not the tile, so the repair has to drop the second reference and leave the tile where the first parent has it.

Deleting it is strictly worse than the sharing it was meant to fix. `simplify` runs right after `gc` in `Tree::ui`, sees the owning container as empty, prunes it, sees *its* parent as empty, prunes that too — and a tree that was merely ill-formed can end up gone entirely, with its panes left unreachable in the arena. Reproduced on `main` by the test in this PR:

```
the shared tile itself must survive - only one of the two references is bogus
```

Sharing needs no unsafe and no private access: `Tiles::insert` is public and takes any id, and a deserialized layout can say anything at all. That is how this was found — fuzzing saved layouts (RON) against the tree's structural invariants, in a fork that has a `Tree::validate` oracle.

The fix is the one-line re-insert plus a regression test; the test fails on `main` and passes with the fix.
