### PR TITLE
Clear the root when garbage collection had to drop it

### DIFF
--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -392,13 +392,22 @@ impl<Pane> Tiles<Pane> {
     /// Will also call [`Behavior::retain_pane`] to check if a users wants to remove a pane.
     ///
     /// Finally free up any tiles that are no longer reachable from the root.
-    pub(super) fn gc_root(&mut self, behavior: &mut dyn Behavior<Pane>, root_id: Option<TileId>) {
+    ///
+    /// Returns whether the root survived. It does not when the tile is missing from the arena, or
+    /// when [`Behavior::retain_pane`] asks for it to go - and the caller owns the root, so it is
+    /// the caller that has to stop calling that tile a root.
+    #[must_use]
+    pub(super) fn gc_root(
+        &mut self,
+        behavior: &mut dyn Behavior<Pane>,
+        root_id: Option<TileId>,
+    ) -> bool {
         let mut visited = Default::default();
 
-        if let Some(root_id) = root_id {
-            // We ignore the returned root action, because we will never remove the root.
-            let _root_action = self.gc_tile_id(behavior, &mut visited, root_id);
-        }
+        let root_kept = match root_id {
+            Some(root_id) => self.gc_tile_id(behavior, &mut visited, root_id) == GcAction::Keep,
+            None => true,
+        };
 
         if visited.len() < self.tiles.len() {
             // This should only happen if the user set up the tree in a bad state,
@@ -415,6 +424,8 @@ impl<Pane> Tiles<Pane> {
 
         self.invisible.retain(|tile_id| visited.contains(tile_id));
         self.tiles.retain(|tile_id, _| visited.contains(tile_id));
+
+        root_kept
     }
 
     /// Detect cycles, duplications, and other invalid state, and remove them.

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -393,9 +393,7 @@ impl<Pane> Tiles<Pane> {
     ///
     /// Finally free up any tiles that are no longer reachable from the root.
     ///
-    /// Returns whether the root survived. It does not when the tile is missing from the arena, or
-    /// when [`Behavior::retain_pane`] asks for it to go - and the caller owns the root, so it is
-    /// the caller that has to stop calling that tile a root.
+    /// Returns whether the root survived.
     #[must_use]
     pub(super) fn gc_root(
         &mut self,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -534,11 +534,6 @@ impl<Pane> Tree<Pane> {
     /// Garbage-collect tiles that are no longer reachable from the root tile.
     ///
     /// This is also called by [`Self::ui`], so usually you don't need to call this yourself.
-    ///
-    /// A root the collector could not keep stops being the root here: either the [`Behavior`]
-    /// asked for that pane to go, or the tile was not in the arena to begin with. Leaving it in
-    /// place would mean `root` names a tile that does not exist - a tree that renders nothing and
-    /// reports `is_empty() == false`, so nothing downstream can even tell that it is empty.
     pub fn gc(&mut self, behavior: &mut dyn Behavior<Pane>) {
         if !self.tiles.gc_root(behavior, self.root) {
             self.root = None;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -534,8 +534,15 @@ impl<Pane> Tree<Pane> {
     /// Garbage-collect tiles that are no longer reachable from the root tile.
     ///
     /// This is also called by [`Self::ui`], so usually you don't need to call this yourself.
+    ///
+    /// A root the collector could not keep stops being the root here: either the [`Behavior`]
+    /// asked for that pane to go, or the tile was not in the arena to begin with. Leaving it in
+    /// place would mean `root` names a tile that does not exist - a tree that renders nothing and
+    /// reports `is_empty() == false`, so nothing downstream can even tell that it is empty.
     pub fn gc(&mut self, behavior: &mut dyn Behavior<Pane>) {
-        self.tiles.gc_root(behavior, self.root);
+        if !self.tiles.gc_root(behavior, self.root) {
+            self.root = None;
+        }
     }
 
     /// Move a tile to a new container, at the specified insertion index.
@@ -815,5 +822,49 @@ mod tests {
             vec![root, dropped],
         );
         assert_eq!(tree.tiles.parent_of(root), Some(new_root));
+    }
+
+    /// Drops one specific pane, the way an application closes a document.
+    struct DropPane(&'static str);
+
+    impl Behavior<&'static str> for DropPane {
+        fn pane_ui(
+            &mut self,
+            _ui: &mut egui::Ui,
+            _tile_id: TileId,
+            _pane: &mut &'static str,
+        ) -> UiResponse {
+            UiResponse::None
+        }
+
+        fn tab_title_for_pane(&mut self, pane: &&'static str) -> egui::WidgetText {
+            (*pane).into()
+        }
+
+        fn retain_pane(&mut self, pane: &&'static str) -> bool {
+            *pane != self.0
+        }
+    }
+
+    /// A root the collector had to drop must stop being the root.
+    ///
+    /// A single pane can be the root - `simplify` produces exactly that once a tab container is
+    /// down to one child - and `retain_pane` is how an application closes it. `gc` then removed
+    /// the tile and left `root` naming it, so the tree rendered nothing while
+    /// `is_empty()` still said `false`: no way for the caller to notice, and no way to recover
+    /// except by writing `tree.root = None` by hand.
+    #[test]
+    fn gc_clears_a_root_it_had_to_drop() {
+        let mut tiles = Tiles::default();
+        let only = tiles.insert_pane("doomed");
+        let mut tree = Tree::new("root_pane", only, tiles);
+
+        tree.gc(&mut DropPane("doomed"));
+
+        assert_eq!(
+            tree.root, None,
+            "the root tile is gone, so the tree must not still name it"
+        );
+        assert!(tree.is_empty(), "an empty tree has to say that it is empty");
     }
 }


### PR DESCRIPTION
`Tiles::gc_root` walks the root and throws the result away — *"we ignore the returned root action, because we will never remove the root"* — but the root can end up removed all the same:

* `Behavior::retain_pane` returning `false` for the root pane is how an application closes its last document, and a single pane **is** the root once `simplify` has dissolved a tab container down to one child;
* a `root` id that is not in the arena at all (a hand-edited or older saved layout) takes the same path.

The tile is then gone while `Tree::root` still names it. On `main` the test in this PR reports:

```
root=Some(#1), tiles=0, is_empty=false
```

The tree renders nothing, `is_empty()` says `false`, so nothing downstream can even tell that it is empty — and there is no way to recover short of writing `tree.root = None` by hand.

`gc_root` now reports whether the root survived, and `Tree::gc` stops calling it the root when it did not.

Independent of #148, which fixes a different way the same pass could delete a tile it should have kept. Both were found by fuzzing saved layouts against the tree's structural invariants.
