### PR TITLE
Let a crowded tab bar wrap into more rows instead of scrolling

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -110,15 +110,11 @@ impl TreeBehavior {
                 ui.end_row();
 
                 ui.label("Max tab bar rows:");
-                ui.add(
-                    egui::DragValue::new(max_tab_bar_rows)
-                        .range(1..=4)
-                        .speed(0.05),
-                )
-                .on_hover_text(
-                    "Above 1, a tab bar too crowded for one row wraps into further rows \
+                ui.add(egui::Slider::new(max_tab_bar_rows, 1..=4))
+                    .on_hover_text(
+                        "Above 1, a tab bar too crowded for one row wraps into further rows \
                      instead of scrolling. Add tabs with ➕, or narrow the window, to see it.",
-                );
+                    );
                 ui.end_row();
 
                 ui.label("Gap width:");

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -60,6 +60,7 @@ impl Pane {
 struct TreeBehavior {
     simplification_options: egui_tiles::SimplificationOptions,
     tab_bar_height: f32,
+    max_tab_bar_rows: usize,
     gap_width: f32,
     add_child_to: Option<egui_tiles::TileId>,
 }
@@ -69,6 +70,7 @@ impl Default for TreeBehavior {
         Self {
             simplification_options: Default::default(),
             tab_bar_height: 24.0,
+            max_tab_bar_rows: 1,
             gap_width: 2.0,
             add_child_to: None,
         }
@@ -80,6 +82,7 @@ impl TreeBehavior {
         let Self {
             simplification_options,
             tab_bar_height,
+            max_tab_bar_rows,
             gap_width,
             add_child_to: _,
         } = self;
@@ -103,6 +106,18 @@ impl TreeBehavior {
                     egui::DragValue::new(tab_bar_height)
                         .range(0.0..=100.0)
                         .speed(1.0),
+                );
+                ui.end_row();
+
+                ui.label("Max tab bar rows:");
+                ui.add(
+                    egui::DragValue::new(max_tab_bar_rows)
+                        .range(1..=4)
+                        .speed(0.05),
+                )
+                .on_hover_text(
+                    "Above 1, a tab bar too crowded for one row wraps into further rows \
+                     instead of scrolling. Add tabs with ➕, or narrow the window, to see it.",
                 );
                 ui.end_row();
 
@@ -161,6 +176,10 @@ impl egui_tiles::Behavior<Pane> for TreeBehavior {
 
     fn tab_bar_height(&self, _style: &egui::Style) -> f32 {
         self.tab_bar_height
+    }
+
+    fn max_tab_bar_rows(&self) -> usize {
+        self.max_tab_bar_rows
     }
 
     fn gap_width(&self, _style: &egui::Style) -> f32 {

--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -45,6 +45,13 @@ pub(crate) struct LayoutContext<'a> {
     pub tab_bar_height: f32,
     pub grid_auto_column_count: &'a dyn Fn(usize, Rect, f32) -> usize,
 
+    /// How many rows a given tab bar took last frame.
+    ///
+    /// A wrapped tab bar is as tall as the rows it needed, and how many that is depends on how
+    /// wide the tabs turned out — which the layout pass runs too early to know. So it reads what
+    /// the last frame measured, and a bar that has just changed shape is one frame behind.
+    pub tab_bar_rows: &'a dyn Fn(TileId) -> usize,
+
     /// Set by the layout pass if it had to pick an active tab for a [`crate::Tabs`] container.
     ///
     /// Reported back to the caller rather than straight to [`Behavior::on_edit`]: laying out
@@ -63,6 +70,7 @@ pub(crate) fn layout_tiles<Pane, TilesPane>(
     root: Option<TileId>,
     behavior: &dyn Behavior<Pane>,
     style: &egui::Style,
+    tab_bar_rows: &dyn Fn(TileId) -> usize,
     rect: Rect,
 ) -> bool {
     let Some(root) = root else {
@@ -78,6 +86,7 @@ pub(crate) fn layout_tiles<Pane, TilesPane>(
         gap_width: behavior.gap_width(style),
         tab_bar_height: behavior.tab_bar_height(style),
         grid_auto_column_count: &grid_auto_column_count,
+        tab_bar_rows,
         tab_auto_selected: &tab_auto_selected,
     };
 
@@ -343,9 +352,24 @@ pub trait Behavior<Pane> {
     ) {
     }
 
-    /// The height of the bar holding tab titles.
+    /// The height of one row of the bar holding tab titles.
     fn tab_bar_height(&self, _style: &egui::Style) -> f32 {
         24.0
+    }
+
+    /// How many rows a tab bar may wrap into before it starts scrolling instead.
+    ///
+    /// The default of `1` keeps a tab bar to a single row that scrolls once the
+    /// tabs no longer fit, with arrows at either end. Raising it lets a crowded
+    /// bar break into further rows first, which is worth it wherever a tab bar
+    /// is narrow — a side panel of eight tabs otherwise hides half of them
+    /// behind an arrow, and a tab you cannot see is a tab you will not use.
+    ///
+    /// Tabs wrap only if they fit within this many rows; beyond that the bar
+    /// falls back to a single scrolling row rather than growing without end.
+    /// Returning `0` is read as `1`.
+    fn max_tab_bar_rows(&self) -> usize {
+        1
     }
 
     /// Width of the gap between tiles in a horizontal or vertical layout,

--- a/src/container/grid.rs
+++ b/src/container/grid.rs
@@ -591,7 +591,14 @@ mod tests {
 
         for _ in 0..1000 {
             let root = tree.root.unwrap();
-            crate::behavior::layout_tiles(&mut tree.tiles, Some(root), &behavior, &style, area);
+            crate::behavior::layout_tiles(
+                &mut tree.tiles,
+                Some(root),
+                &behavior,
+                &style,
+                &|_| 1,
+                area,
+            );
 
             // Add some tiles:
             for _ in 0..rng.rand_u64() % 3 {

--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -12,6 +12,7 @@ mod tabs;
 pub use grid::{Grid, GridLayout};
 pub use linear::{Linear, LinearDir, Shares};
 pub use tabs::Tabs;
+pub(crate) use tabs::tab_bar_rows;
 
 // ----------------------------------------------------------------------------
 
@@ -239,13 +240,14 @@ impl Container {
         tiles: &mut Tiles<Pane>,
         layout: &LayoutContext<'_>,
         rect: Rect,
+        tile_id: TileId,
     ) {
         if self.is_empty() {
             return;
         }
 
         match self {
-            Self::Tabs(tabs) => tabs.layout(tiles, layout, rect),
+            Self::Tabs(tabs) => tabs.layout(tiles, layout, rect, tile_id),
             Self::Linear(linear) => {
                 linear.layout(tiles, layout, rect);
             }

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -60,6 +60,9 @@ pub(crate) struct WrapState {
 
     /// The width of each tab, in the order the tabs were drawn.
     pub widths: Vec<f32>,
+
+    /// The width [`Behavior::top_bar_right_ui`] took, which the tabs have to leave free.
+    pub right_width: f32,
 }
 
 /// What one pass over the tabs produced, whether they wrapped or scrolled.
@@ -77,7 +80,10 @@ struct TabBarOutput {
     /// The width of each tab drawn, in order, to wrap by next frame.
     widths: Vec<f32>,
 
-    /// How many rows the tabs took, or zero if wrapping was not tried or did not fit.
+    /// The width [`Behavior::top_bar_right_ui`] took, to wrap by next frame.
+    right_width: f32,
+
+    /// How many rows the tabs took.
     rows: usize,
 }
 
@@ -346,8 +352,8 @@ impl Tabs {
             ..TabBarOutput::default()
         };
 
-        if max_rows > 1 {
-            self.wrapping_tab_bar_ui(
+        let wrapped = max_rows > 1
+            && self.wrapping_tab_bar_ui(
                 tree,
                 behavior,
                 &mut ui,
@@ -360,9 +366,8 @@ impl Tabs {
                 },
                 &mut output,
             );
-        }
 
-        if output.rows == 0 {
+        if !wrapped {
             self.scrolling_tab_bar_ui(
                 tree,
                 behavior,
@@ -380,7 +385,17 @@ impl Tabs {
         }
         let widths = std::mem::take(&mut output.widths);
         let rows = output.rows;
-        ui.data_mut(|data| data.insert_temp(wrap_id, WrapState { rows, widths }));
+        let right_width = output.right_width;
+        ui.data_mut(|data| {
+            data.insert_temp(
+                wrap_id,
+                WrapState {
+                    rows,
+                    widths,
+                    right_width,
+                },
+            );
+        });
 
         self.tab_drop_zones(&ui, drop_context, tile_id, &output);
 
@@ -426,8 +441,10 @@ impl Tabs {
 
     /// Draws every tab in one row per line, when they fit within the allowed number of rows.
     ///
-    /// Leaves `output.rows` at zero if they do not, which is the caller's signal to fall back to
-    /// a single scrolling row.
+    /// Returns `false` without drawing anything if they do not, which is the caller's signal to
+    /// fall back to a single scrolling row. Both the tab widths and the width of
+    /// [`Behavior::top_bar_right_ui`] come from what the previous frame measured, so that deciding
+    /// whether the tabs fit draws nothing that the fallback would then draw a second time.
     fn wrapping_tab_bar_ui<Pane>(
         &self,
         tree: &mut Tree<Pane>,
@@ -436,13 +453,29 @@ impl Tabs {
         drop_context: &DropContext,
         wrap: &WrapLayout<'_>,
         output: &mut TabBarOutput,
-    ) {
+    ) -> bool {
         let tile_id = wrap.tile_id;
         let bar_rect = ui.max_rect();
+        let available = bar_rect.width() - wrap.previous.right_width;
+
+        let visible: Vec<(usize, TileId)> = self
+            .children
+            .iter()
+            .enumerate()
+            .filter(|&(_, &child_id)| tree.is_visible(child_id))
+            .map(|(index, &child_id)| (index, child_id))
+            .collect();
+
+        let Some(plan) = wrap_rows(&wrap.previous.widths, available, wrap.max_rows) else {
+            return false;
+        };
+        if plan.iter().sum::<usize>() != visible.len() {
+            return false;
+        }
+
         let first_row = bar_rect
             .split_top_bottom_at_y(bar_rect.top() + wrap.row_height)
             .0;
-
         let mut right_ui = ui.new_child(
             egui::UiBuilder::new()
                 .max_rect(first_row)
@@ -456,22 +489,7 @@ impl Tabs {
             self,
             &mut unused_offset,
         );
-        let available = bar_rect.width() - right_ui.min_rect().width();
-
-        let visible: Vec<(usize, TileId)> = self
-            .children
-            .iter()
-            .enumerate()
-            .filter(|&(_, &child_id)| tree.is_visible(child_id))
-            .map(|(index, &child_id)| (index, child_id))
-            .collect();
-
-        let Some(plan) = wrap_rows(&wrap.previous.widths, available, wrap.max_rows) else {
-            return;
-        };
-        if plan.iter().sum::<usize>() != visible.len() {
-            return;
-        }
+        output.right_width = right_ui.min_rect().width();
 
         Self::drag_background(tree, behavior, ui, tile_id);
 
@@ -502,6 +520,7 @@ impl Tabs {
             drawn += count;
         }
         output.rows = plan.len();
+        true
     }
 
     fn drag_background<Pane>(
@@ -594,7 +613,9 @@ impl Tabs {
 
             // Allow user to add buttons such as "add new tab".
             // They can also read and modify the scroll state if they want.
+            let before_right_ui = ui.min_rect().width();
             behavior.top_bar_right_ui(&tree.tiles, ui, tile_id, self, &mut scroll_state.offset);
+            output.right_width = ui.min_rect().width() - before_right_ui;
 
             let scroll_area_width = scroll_state.update(ui, arrow_size);
 

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -49,6 +49,84 @@ struct ScrollState {
     pub showed_right_arrow_prev: bool,
 }
 
+/// What a wrapped tab bar measured last frame.
+///
+/// Kept in `egui`'s temporary memory rather than in [`Tabs`], so that adding it breaks no
+/// caller's struct literal, and so the layout pass can read it without a tile at hand.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct WrapState {
+    /// How many rows the tabs took.
+    pub rows: usize,
+
+    /// The width of each tab, in the order the tabs were drawn.
+    pub widths: Vec<f32>,
+}
+
+/// What one pass over the tabs produced, whether they wrapped or scrolled.
+#[derive(Default)]
+struct TabBarOutput {
+    /// The tab to open next frame — the one clicked, or the one already open.
+    next_active: Option<TileId>,
+
+    /// Where each tab ended up, for the drop zones.
+    button_rects: ahash::HashMap<TileId, Rect>,
+
+    /// Index into [`Tabs::children`] of the tab being dragged, if any.
+    dragged_index: Option<usize>,
+
+    /// The width of each tab drawn, in order, to wrap by next frame.
+    widths: Vec<f32>,
+
+    /// How many rows the tabs took, or zero if wrapping was not tried or did not fit.
+    rows: usize,
+}
+
+struct WrapLayout<'a> {
+    tile_id: TileId,
+    row_height: f32,
+    max_rows: usize,
+    previous: &'a WrapState,
+}
+
+pub(crate) fn wrap_state_id(tile_id: TileId, tree_id: egui::Id) -> egui::Id {
+    tile_id.egui_id(tree_id).with("tab_bar_wrap")
+}
+
+/// How many rows the tab bar of `tile_id` took last frame, or 1 if it has not been drawn yet.
+pub(crate) fn tab_bar_rows(context: &egui::Context, tile_id: TileId, tree_id: egui::Id) -> usize {
+    context
+        .data(|data| data.get_temp::<WrapState>(wrap_state_id(tile_id, tree_id)))
+        .map_or(1, |state| state.rows.max(1))
+}
+
+/// Splits `widths` into rows no wider than `available`, or `None` if that needs more than
+/// `max_rows`.
+///
+/// Greedy, which is what a tab bar wants: tabs keep their order, and a row is filled before the
+/// next one is started, so a tab only ever moves down when the one before it no longer fits.
+fn wrap_rows(widths: &[f32], available: f32, max_rows: usize) -> Option<Vec<usize>> {
+    if widths.is_empty() {
+        return Some(vec![0]);
+    }
+    let mut rows = vec![0usize];
+    let mut used = 0.0;
+    for &width in widths {
+        let fits = used == 0.0 || used + width <= available;
+        if !fits {
+            if rows.len() >= max_rows {
+                return None;
+            }
+            rows.push(0);
+            used = 0.0;
+        }
+        if let Some(row) = rows.last_mut() {
+            *row += 1;
+        }
+        used += width;
+    }
+    Some(rows)
+}
+
 impl ScrollState {
     /// Returns the space left for the tabs after the scroll arrows.
     pub fn update(&mut self, ui: &egui::Ui, arrow_size: Vec2) -> f32 {
@@ -179,6 +257,7 @@ impl Tabs {
         tiles: &mut Tiles<Pane>,
         layout: &LayoutContext<'_>,
         rect: Rect,
+        tile_id: TileId,
     ) {
         let prev_active = self.active;
         self.ensure_active(tiles);
@@ -187,7 +266,7 @@ impl Tabs {
         }
 
         let mut active_rect = rect;
-        active_rect.min.y += layout.tab_bar_height;
+        active_rect.min.y += layout.tab_bar_height * (layout.tab_bar_rows)(tile_id) as f32;
 
         if let Some(active) = self.active {
             // Only lay out the active tab (saves CPU):
@@ -241,18 +320,269 @@ impl Tabs {
         drop_context: &mut DropContext,
         tile_id: TileId,
     ) -> Option<TileId> {
-        let mut next_active = self.active;
+        let row_height = behavior.tab_bar_height(ui.style());
+        let max_rows = behavior.max_tab_bar_rows().max(1);
 
-        let tab_bar_height = behavior.tab_bar_height(ui.style());
-        let arrow_size = egui::Vec2::splat(tab_bar_height);
-        let tab_bar_rect = rect.split_top_bottom_at_y(rect.top() + tab_bar_height).0;
+        let wrap_id = wrap_state_id(tile_id, tree.id);
+        let previous = ui
+            .data(|data| data.get_temp::<WrapState>(wrap_id))
+            .unwrap_or_default();
+        let rows_reserved = if max_rows > 1 {
+            previous.rows.clamp(1, max_rows)
+        } else {
+            1
+        };
+
+        let tab_bar_rect = rect
+            .split_top_bottom_at_y(rect.top() + row_height * rows_reserved as f32)
+            .0;
         let mut ui = ui.new_child(egui::UiBuilder::new().max_rect(tab_bar_rect));
-
-        let mut button_rects = ahash::HashMap::default();
-        let mut dragged_index = None;
 
         ui.painter()
             .rect_filled(ui.max_rect(), 0.0, behavior.tab_bar_color(ui.visuals()));
+
+        let mut output = TabBarOutput {
+            next_active: self.active,
+            ..TabBarOutput::default()
+        };
+
+        if max_rows > 1 {
+            self.wrapping_tab_bar_ui(
+                tree,
+                behavior,
+                &mut ui,
+                drop_context,
+                &WrapLayout {
+                    tile_id,
+                    row_height,
+                    max_rows,
+                    previous: &previous,
+                },
+                &mut output,
+            );
+        }
+
+        if output.rows == 0 {
+            self.scrolling_tab_bar_ui(
+                tree,
+                behavior,
+                &mut ui,
+                drop_context,
+                tile_id,
+                row_height,
+                &mut output,
+            );
+            output.rows = 1;
+        }
+
+        if output.rows != rows_reserved {
+            ui.ctx().request_repaint();
+        }
+        let widths = std::mem::take(&mut output.widths);
+        let rows = output.rows;
+        ui.data_mut(|data| data.insert_temp(wrap_id, WrapState { rows, widths }));
+
+        self.tab_drop_zones(&ui, drop_context, tile_id, &output);
+
+        output.next_active
+    }
+
+    fn tab_drop_zones(
+        &self,
+        ui: &egui::Ui,
+        drop_context: &mut DropContext,
+        tile_id: TileId,
+        output: &TabBarOutput,
+    ) {
+        let preview_thickness = 6.0;
+        let dragged_index = output.dragged_index;
+        let button_rects = &output.button_rects;
+        let after_rect = |rect: Rect| {
+            let dragged_size = if let Some(dragged_index) = dragged_index {
+                button_rects[&self.children[dragged_index]].size()
+            } else {
+                rect.size()
+            };
+            Rect::from_min_size(
+                rect.right_top() + vec2(ui.spacing().item_spacing.x, 0.0),
+                dragged_size,
+            )
+        };
+        super::linear::drop_zones(
+            preview_thickness,
+            &self.children,
+            dragged_index,
+            super::LinearDir::Horizontal,
+            |tile_id| button_rects.get(&tile_id).copied(),
+            |rect, i| {
+                drop_context.suggest_rect(
+                    InsertionPoint::new(tile_id, ContainerInsertion::Tabs(i)),
+                    rect,
+                );
+            },
+            after_rect,
+        );
+    }
+
+    /// Draws every tab in one row per line, when they fit within the allowed number of rows.
+    ///
+    /// Leaves `output.rows` at zero if they do not, which is the caller's signal to fall back to
+    /// a single scrolling row.
+    fn wrapping_tab_bar_ui<Pane>(
+        &self,
+        tree: &mut Tree<Pane>,
+        behavior: &mut dyn Behavior<Pane>,
+        ui: &mut egui::Ui,
+        drop_context: &DropContext,
+        wrap: &WrapLayout<'_>,
+        output: &mut TabBarOutput,
+    ) {
+        let tile_id = wrap.tile_id;
+        let bar_rect = ui.max_rect();
+        let first_row = bar_rect
+            .split_top_bottom_at_y(bar_rect.top() + wrap.row_height)
+            .0;
+
+        let mut right_ui = ui.new_child(
+            egui::UiBuilder::new()
+                .max_rect(first_row)
+                .layout(egui::Layout::right_to_left(egui::Align::Center)),
+        );
+        let mut unused_offset = 0.0;
+        behavior.top_bar_right_ui(
+            &tree.tiles,
+            &mut right_ui,
+            tile_id,
+            self,
+            &mut unused_offset,
+        );
+        let available = bar_rect.width() - right_ui.min_rect().width();
+
+        let visible: Vec<(usize, TileId)> = self
+            .children
+            .iter()
+            .enumerate()
+            .filter(|&(_, &child_id)| tree.is_visible(child_id))
+            .map(|(index, &child_id)| (index, child_id))
+            .collect();
+
+        let Some(plan) = wrap_rows(&wrap.previous.widths, available, wrap.max_rows) else {
+            return;
+        };
+        if plan.iter().sum::<usize>() != visible.len() {
+            return;
+        }
+
+        Self::drag_background(tree, behavior, ui, tile_id);
+
+        let mut drawn = 0;
+        for (row_index, count) in plan.iter().enumerate() {
+            let top = bar_rect.top() + wrap.row_height * row_index as f32;
+            let row_rect = Rect::from_min_size(
+                egui::pos2(bar_rect.left(), top),
+                vec2(available, wrap.row_height),
+            );
+            let mut row_ui = ui.new_child(
+                egui::UiBuilder::new()
+                    .max_rect(row_rect)
+                    .layout(egui::Layout::left_to_right(egui::Align::Center)),
+            );
+            row_ui.spacing_mut().item_spacing.x = 0.0;
+            self.tabs_ui(
+                tree,
+                behavior,
+                &mut row_ui,
+                drop_context,
+                &visible[drawn..drawn + count],
+                output,
+            );
+            if row_index + 1 == plan.len() {
+                behavior.tab_bar_trailing_ui(&tree.tiles, &mut row_ui, tile_id, self);
+            }
+            drawn += count;
+        }
+        output.rows = plan.len();
+    }
+
+    fn drag_background<Pane>(
+        tree: &Tree<Pane>,
+        behavior: &mut dyn Behavior<Pane>,
+        ui: &egui::Ui,
+        tile_id: TileId,
+    ) {
+        if tree.is_root(tile_id) || !behavior.is_tile_draggable(&tree.tiles, tile_id) {
+            return;
+        }
+        let sense = egui::Sense::click_and_drag();
+        if ui
+            .interact(ui.max_rect(), ui.id().with("background"), sense)
+            .on_hover_cursor(egui::CursorIcon::Grab)
+            .drag_started()
+        {
+            behavior.on_edit(EditAction::TileDragged);
+            ui.set_dragged_id(tile_id.egui_id(tree.id));
+        }
+    }
+
+    fn tabs_ui<Pane>(
+        &self,
+        tree: &mut Tree<Pane>,
+        behavior: &mut dyn Behavior<Pane>,
+        ui: &mut egui::Ui,
+        drop_context: &DropContext,
+        children: &[(usize, TileId)],
+        output: &mut TabBarOutput,
+    ) {
+        for &(index, child_id) in children {
+            let is_being_dragged = is_being_dragged(ui, tree.id, child_id);
+            let tab_state = TabState {
+                active: self.is_active(child_id),
+                is_being_dragged,
+                closable: behavior.is_tab_closable(&tree.tiles, child_id),
+            };
+            let id = child_id.egui_id(tree.id);
+            let response = behavior.tab_ui(&mut tree.tiles, ui, id, child_id, &tab_state);
+
+            if response.clicked() {
+                behavior.on_edit(EditAction::TabSelected);
+                output.next_active = Some(child_id);
+            }
+
+            if let Some(mouse_pos) = drop_context.mouse_pos
+                && drop_context.dragged_tile_id.is_some()
+                && response.rect.contains(mouse_pos)
+            {
+                behavior.on_edit(EditAction::TabSelected);
+                output.next_active = Some(child_id);
+            }
+
+            output.widths.push(response.rect.width());
+            output.button_rects.insert(child_id, response.rect);
+            if is_being_dragged {
+                output.dragged_index = Some(index);
+            }
+        }
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    fn scrolling_tab_bar_ui<Pane>(
+        &self,
+        tree: &mut Tree<Pane>,
+        behavior: &mut dyn Behavior<Pane>,
+        ui: &mut egui::Ui,
+        drop_context: &DropContext,
+        tile_id: TileId,
+        tab_bar_height: f32,
+        output: &mut TabBarOutput,
+    ) {
+        let arrow_size = egui::Vec2::splat(tab_bar_height);
+        let visible: Vec<(usize, TileId)> = self
+            .children
+            .iter()
+            .enumerate()
+            .filter(|&(_, &child_id)| tree.is_visible(child_id))
+            .map(|(index, &child_id)| (index, child_id))
+            .collect();
 
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
             let scroll_state_id = ui.make_persistent_id(tile_id);
@@ -292,109 +622,26 @@ impl Tabs {
                         .auto_shrink([false; 2])
                         .horizontal_scroll_offset(scroll_state.offset);
 
-                    let output = scroll_area.show(ui, |ui| {
-                        if !tree.is_root(tile_id)
-                            && behavior.is_tile_draggable(&tree.tiles, tile_id)
-                        {
-                            // Make the background behind the buttons draggable (to drag the parent container tile).
-                            // We also sense clicks to avoid eager-dragging on mouse-down.
-                            let sense = egui::Sense::click_and_drag();
-                            if ui
-                                .interact(ui.max_rect(), ui.id().with("background"), sense)
-                                .on_hover_cursor(egui::CursorIcon::Grab)
-                                .drag_started()
-                            {
-                                behavior.on_edit(EditAction::TileDragged);
-                                ui.set_dragged_id(tile_id.egui_id(tree.id));
-                            }
-                        }
+                    let scrolled = scroll_area.show(ui, |ui| {
+                        Self::drag_background(tree, behavior, ui, tile_id);
 
                         ui.spacing_mut().item_spacing.x = 0.0; // Tabs have spacing built-in
 
-                        for (i, &child_id) in self.children.iter().enumerate() {
-                            if !tree.is_visible(child_id) {
-                                continue;
-                            }
-
-                            let is_being_dragged = is_being_dragged(ui, tree.id, child_id);
-
-                            let selected = self.is_active(child_id);
-                            let id = child_id.egui_id(tree.id);
-                            let tab_state = TabState {
-                                active: selected,
-                                is_being_dragged,
-                                closable: behavior.is_tab_closable(&tree.tiles, child_id),
-                            };
-
-                            let response =
-                                behavior.tab_ui(&mut tree.tiles, ui, id, child_id, &tab_state);
-
-                            if response.clicked() {
-                                behavior.on_edit(EditAction::TabSelected);
-                                next_active = Some(child_id);
-                            }
-
-                            if let Some(mouse_pos) = drop_context.mouse_pos
-                                && drop_context.dragged_tile_id.is_some()
-                                && response.rect.contains(mouse_pos)
-                            {
-                                // Expand this tab - maybe the user wants to drop something into it!
-                                behavior.on_edit(EditAction::TabSelected);
-                                next_active = Some(child_id);
-                            }
-
-                            button_rects.insert(child_id, response.rect);
-                            if is_being_dragged {
-                                dragged_index = Some(i);
-                            }
-                        }
+                        self.tabs_ui(tree, behavior, ui, drop_context, &visible, output);
 
                         // Allow the user to add a trailing widget after the last tab
                         // (e.g. a "➕" button), inside the tab scroll area's flow.
                         behavior.tab_bar_trailing_ui(&tree.tiles, ui, tile_id, self);
                     });
 
-                    scroll_state.offset = output.state.offset.x;
-                    scroll_state.content_size = output.content_size;
-                    scroll_state.available = output.inner_rect.size();
+                    scroll_state.offset = scrolled.state.offset.x;
+                    scroll_state.content_size = scrolled.content_size;
+                    scroll_state.available = scrolled.inner_rect.size();
                 },
             );
 
             ui.data_mut(|data| data.insert_temp(scroll_state_id, scroll_state));
         });
-
-        // -----------
-        // Drop zones:
-
-        let preview_thickness = 6.0;
-        let after_rect = |rect: Rect| {
-            let dragged_size = if let Some(dragged_index) = dragged_index {
-                // We actually know the size of this thing
-                button_rects[&self.children[dragged_index]].size()
-            } else {
-                rect.size() // guess that the size is the same as the last button
-            };
-            Rect::from_min_size(
-                rect.right_top() + vec2(ui.spacing().item_spacing.x, 0.0),
-                dragged_size,
-            )
-        };
-        super::linear::drop_zones(
-            preview_thickness,
-            &self.children,
-            dragged_index,
-            super::LinearDir::Horizontal,
-            |tile_id| button_rects.get(&tile_id).copied(),
-            |rect, i| {
-                drop_context.suggest_rect(
-                    InsertionPoint::new(tile_id, ContainerInsertion::Tabs(i)),
-                    rect,
-                );
-            },
-            after_rect,
-        );
-
-        next_active
     }
 
     pub(super) fn simplify_children(&mut self, mut simplify: impl FnMut(TileId) -> SimplifyAction) {
@@ -416,5 +663,35 @@ impl Tabs {
         let index = self.children.iter().position(|&child| child == needle)?;
         self.children.remove(index);
         Some(index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wrap_rows;
+
+    #[test]
+    fn tabs_that_fit_stay_on_one_row() {
+        assert_eq!(wrap_rows(&[30.0, 30.0, 30.0], 100.0, 2), Some(vec![3]));
+    }
+
+    #[test]
+    fn a_row_is_filled_before_the_next_one_is_started() {
+        assert_eq!(wrap_rows(&[60.0, 60.0, 30.0], 100.0, 2), Some(vec![1, 2]));
+    }
+
+    #[test]
+    fn tabs_that_need_more_rows_than_allowed_do_not_wrap() {
+        assert_eq!(wrap_rows(&[60.0, 60.0, 60.0], 100.0, 2), None);
+    }
+
+    #[test]
+    fn a_tab_wider_than_the_bar_still_gets_its_own_row() {
+        assert_eq!(wrap_rows(&[300.0, 30.0], 100.0, 2), Some(vec![1, 1]));
+    }
+
+    #[test]
+    fn an_empty_bar_is_one_row() {
+        assert_eq!(wrap_rows(&[], 100.0, 2), Some(vec![0]));
     }
 }

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -455,7 +455,7 @@ impl<Pane> Tiles<Pane> {
         self.rects.insert(tile_id, rect);
 
         if let Tile::Container(container) = &mut tile {
-            container.layout(self, layout, rect);
+            container.layout(self, layout, rect, tile_id);
         }
 
         self.tiles.insert(tile_id, tile);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -328,7 +328,24 @@ impl<Pane> Tree<Pane> {
         if self.width.is_finite() {
             rect.set_width(self.width);
         }
-        if layout_tiles(&mut self.tiles, self.root, behavior, ui.style(), rect) {
+        let max_tab_bar_rows = behavior.max_tab_bar_rows().max(1);
+        let tree_id = self.id;
+        let tab_bar_rows = |tile_id| {
+            if max_tab_bar_rows <= 1 {
+                1
+            } else {
+                crate::container::tab_bar_rows(ui.ctx(), tile_id, tree_id)
+                    .clamp(1, max_tab_bar_rows)
+            }
+        };
+        if layout_tiles(
+            &mut self.tiles,
+            self.root,
+            behavior,
+            ui.style(),
+            &tab_bar_rows,
+            rect,
+        ) {
             behavior.on_edit(EditAction::TabSelected);
         }
 

--- a/tests/wrapping_tab_bar.rs
+++ b/tests/wrapping_tab_bar.rs
@@ -4,13 +4,25 @@
 //! The rows are measured a frame late — the layout pass runs before anything knows how wide a tab
 //! turned out — so these tests run several frames before looking.
 
-use std::cell::Cell;
+use std::{cell::Cell, rc::Rc};
 
 use egui_kittest::{Harness, kittest::Queryable as _};
-use egui_tiles::{Behavior, Container, Tile, TileId, Tiles, Tree, UiResponse};
+use egui_tiles::{Behavior, Container, Tabs, Tile, TileId, Tiles, Tree, UiResponse};
 
 struct Panes {
     max_rows: usize,
+    right_ui_width: f32,
+    right_ui_calls: Rc<Cell<usize>>,
+}
+
+impl Panes {
+    fn new(max_rows: usize) -> Self {
+        Self {
+            max_rows,
+            right_ui_width: 16.0,
+            right_ui_calls: Rc::default(),
+        }
+    }
 }
 
 impl Behavior<String> for Panes {
@@ -21,6 +33,21 @@ impl Behavior<String> for Panes {
 
     fn tab_title_for_pane(&mut self, pane: &String) -> egui::WidgetText {
         pane.clone().into()
+    }
+
+    fn top_bar_right_ui(
+        &mut self,
+        _tiles: &Tiles<String>,
+        ui: &mut egui::Ui,
+        _tile_id: TileId,
+        _tabs: &Tabs,
+        _scroll_offset: &mut f32,
+    ) {
+        self.right_ui_calls.set(self.right_ui_calls.get() + 1);
+        ui.add_sized(
+            egui::vec2(self.right_ui_width, ui.available_height()),
+            egui::Label::new("➕"),
+        );
     }
 
     fn max_tab_bar_rows(&self) -> usize {
@@ -49,7 +76,7 @@ fn tree() -> Tree<String> {
 /// Runs the tree in a bar too narrow for one row, and returns how tall the tab bar came out.
 fn tab_bar_height(max_rows: usize) -> f32 {
     let mut tree = tree();
-    let mut behavior = Panes { max_rows };
+    let mut behavior = Panes::new(max_rows);
     let height = Cell::new(0.0);
     let mut harness = Harness::builder()
         .with_size(egui::vec2(220.0, 300.0))
@@ -88,10 +115,73 @@ fn one_row_is_the_default_and_keeps_scrolling() {
     );
 }
 
+/// The frame in which wrapping is measured but does not fit falls back to the scrolling row, and
+/// only one of the two may draw the widgets the caller put in the bar.
+#[test]
+fn the_bar_is_drawn_by_one_path_per_frame() {
+    let mut tree = tree();
+    let mut behavior = Panes::new(3);
+    let calls = Rc::clone(&behavior.right_ui_calls);
+    let most_calls_in_a_frame = Rc::new(Cell::new(0));
+    let watched = Rc::clone(&most_calls_in_a_frame);
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(220.0, 300.0))
+        .build_ui(|ui| {
+            calls.set(0);
+            tree.ui(&mut behavior, ui);
+            watched.set(watched.get().max(calls.get()));
+        });
+    for _ in 0..4 {
+        harness.run();
+    }
+
+    assert_eq!(
+        most_calls_in_a_frame.get(),
+        1,
+        "top_bar_right_ui should run once per frame, not once per layout attempt"
+    );
+}
+
+/// Wrapping plans its rows from what the previous frame measured, so the width it leaves for
+/// [`Behavior::top_bar_right_ui`] has to survive the trip through that memory.
+#[test]
+fn wrapped_tabs_leave_room_for_the_top_bar_right_ui() {
+    let mut tree = tree();
+    let mut behavior = Panes {
+        right_ui_width: 80.0,
+        ..Panes::new(4)
+    };
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(220.0, 300.0))
+        .build_ui(|ui| {
+            tree.ui(&mut behavior, ui);
+        });
+    for _ in 0..4 {
+        harness.run();
+    }
+
+    let right_ui = harness
+        .query_by_label("➕")
+        .expect("the top bar right ui should be drawn")
+        .rect();
+    for title in TITLES {
+        let tab = harness
+            .query_by_label(title)
+            .expect("every tab should be drawn")
+            .rect();
+        assert!(
+            tab.right() <= right_ui.left() + 0.5,
+            "{title} ends at {}, overlapping the top bar right ui at {}",
+            tab.right(),
+            right_ui.left()
+        );
+    }
+}
+
 #[test]
 fn every_tab_is_reachable_once_the_bar_wraps() {
     let mut tree = tree();
-    let mut behavior = Panes { max_rows: 3 };
+    let mut behavior = Panes::new(3);
     let mut harness = Harness::builder()
         .with_size(egui::vec2(220.0, 300.0))
         .build_ui(|ui| {

--- a/tests/wrapping_tab_bar.rs
+++ b/tests/wrapping_tab_bar.rs
@@ -1,0 +1,109 @@
+//! A tab bar narrower than its tabs hides them behind a scroll arrow, which is the one thing a tab
+//! bar is meant not to do. [`Behavior::max_tab_bar_rows`] lets it break into further rows instead.
+//!
+//! The rows are measured a frame late — the layout pass runs before anything knows how wide a tab
+//! turned out — so these tests run several frames before looking.
+
+use std::cell::Cell;
+
+use egui_kittest::{Harness, kittest::Queryable as _};
+use egui_tiles::{Behavior, Container, Tile, TileId, Tiles, Tree, UiResponse};
+
+struct Panes {
+    max_rows: usize,
+}
+
+impl Behavior<String> for Panes {
+    fn pane_ui(&mut self, ui: &mut egui::Ui, _tile_id: TileId, pane: &mut String) -> UiResponse {
+        ui.label(format!("inside {pane}"));
+        UiResponse::None
+    }
+
+    fn tab_title_for_pane(&mut self, pane: &String) -> egui::WidgetText {
+        pane.clone().into()
+    }
+
+    fn max_tab_bar_rows(&self) -> usize {
+        self.max_rows
+    }
+
+    fn tab_bar_height(&self, _style: &egui::Style) -> f32 {
+        24.0
+    }
+}
+
+const TITLES: [&str; 6] = ["Sounds", "Layers", "Motifs", "Tunings", "Waves", "Imports"];
+
+const ROW_HEIGHT: f32 = 24.0;
+
+fn tree() -> Tree<String> {
+    let mut tiles = Tiles::default();
+    let panes = TITLES
+        .iter()
+        .map(|title| tiles.insert_pane((*title).to_owned()))
+        .collect();
+    let root = tiles.insert_tab_tile(panes);
+    Tree::new("bar", root, tiles)
+}
+
+/// Runs the tree in a bar too narrow for one row, and returns how tall the tab bar came out.
+fn tab_bar_height(max_rows: usize) -> f32 {
+    let mut tree = tree();
+    let mut behavior = Panes { max_rows };
+    let height = Cell::new(0.0);
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(220.0, 300.0))
+        .build_ui(|ui| {
+            tree.ui(&mut behavior, ui);
+            let pane = tree.root.and_then(|root| match tree.tiles.get(root) {
+                Some(Tile::Container(Container::Tabs(tabs))) => tabs.active,
+                _ => None,
+            });
+            if let (Some(root), Some(pane)) = (tree.root, pane)
+                && let (Some(bar), Some(pane)) = (tree.tiles.rect(root), tree.tiles.rect(pane))
+            {
+                height.set(pane.top() - bar.top());
+            }
+        });
+    harness.run();
+    harness.run();
+    height.get()
+}
+
+#[test]
+fn a_crowded_bar_wraps_into_further_rows() {
+    let wrapped = tab_bar_height(3);
+    assert!(
+        wrapped >= ROW_HEIGHT * 2.0,
+        "six tabs in a 220 px bar should take more than one row, got {wrapped}"
+    );
+}
+
+#[test]
+fn one_row_is_the_default_and_keeps_scrolling() {
+    let height = tab_bar_height(1);
+    assert!(
+        (height - ROW_HEIGHT).abs() < 0.5,
+        "an unwrapped bar should stay one row tall, got {height}"
+    );
+}
+
+#[test]
+fn every_tab_is_reachable_once_the_bar_wraps() {
+    let mut tree = tree();
+    let mut behavior = Panes { max_rows: 3 };
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(220.0, 300.0))
+        .build_ui(|ui| {
+            tree.ui(&mut behavior, ui);
+        });
+    harness.run();
+    harness.run();
+
+    for title in TITLES {
+        assert!(
+            harness.query_by_label(title).is_some(),
+            "{title} should be visible in a wrapped tab bar"
+        );
+    }
+}


### PR DESCRIPTION
A tab bar in a side panel is narrow, and everything stays on one scrolling row — eight tabs in a 220 px panel means four live behind a `▶`. Towards #2, but by wrapping rather than a dropdown.

One opt-in hook:

```rust
fn max_tab_bar_rows(&self) -> usize { 1 }
```

The default is today's behaviour exactly, so nothing here is breaking. Above 1, a crowded bar wraps; if it needs more rows than allowed, it falls back to the single scrolling row rather than growing without end.
