### PR TITLE
Pin typos to v1.49.0 instead of tracking `master`

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -16,4 +16,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check spelling of entire workspace
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.49.0


### PR DESCRIPTION
`crate-ci/typos@master` is a branch ref, so CI ran whatever was last pushed there. Pinned to latest release v1.49.0 (2026-08-03).