### PR TITLE
Fix visibility layouting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # `egui_tiles` Changelog
 Full diff at https://github.com/rerun-io/egui_tiles/compare/0.16.0..HEAD
 
+## Unreleased
+
+### Other changes:
+* Don't lay out a container that has nothing visible to show.
+
+
 ## 0.17.0 - 2026-08-05
 
 ### Breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,6 @@
 # `egui_tiles` Changelog
 Full diff at https://github.com/rerun-io/egui_tiles/compare/0.16.0..HEAD
 
-## Unreleased
-
-### Other changes:
-* Don't lay out a container that has nothing visible to show.
-
-
 ## 0.17.0 - 2026-08-05
 
 ### Breaking changes:

--- a/src/container/grid.rs
+++ b/src/container/grid.rs
@@ -142,7 +142,7 @@ impl Grid {
     fn visible_children_and_holes<Pane>(&self, tiles: &Tiles<Pane>) -> Vec<Option<TileId>> {
         self.children
             .iter()
-            .filter(|id| id.is_none_or(|id| tiles.is_visible(id)))
+            .filter(|id| id.is_none_or(|id| tiles.is_visible_in_layout(id)))
             .copied()
             .collect()
     }
@@ -264,7 +264,7 @@ impl Grid {
     ) {
         for &child in &self.children {
             if let Some(child) = child
-                && tree.is_visible(child)
+                && tree.is_visible_in_layout(child)
             {
                 tree.tile_ui(behavior, drop_context, ui, child);
                 crate::cover_tile_if_dragged(tree, behavior, ui, child);

--- a/src/container/linear.rs
+++ b/src/container/linear.rs
@@ -120,7 +120,7 @@ impl Linear {
         self.children
             .iter()
             .copied()
-            .filter(|&child_id| tiles.is_visible(child_id))
+            .filter(|&child_id| tiles.is_visible_in_layout(child_id))
             .collect()
     }
 

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -197,12 +197,12 @@ impl Tabs {
 
     pub fn next_active<Pane>(&self, tiles: &Tiles<Pane>) -> Option<TileId> {
         self.active
-            .filter(|active| self.children.contains(active) && tiles.is_visible(*active))
+            .filter(|active| self.children.contains(active) && tiles.is_visible_in_layout(*active))
             .or_else(|| {
                 self.children
                     .iter()
                     .copied()
-                    .find(|&child_id| tiles.is_visible(child_id))
+                    .find(|&child_id| tiles.is_visible_in_layout(child_id))
             })
     }
 
@@ -322,7 +322,7 @@ impl Tabs {
                         ui.spacing_mut().item_spacing.x = 0.0; // Tabs have spacing built-in
 
                         for (i, &child_id) in self.children.iter().enumerate() {
-                            if !tree.is_visible(child_id) {
+                            if !tree.is_visible_in_layout(child_id) {
                                 continue;
                             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,10 @@
 //! Invisible tiles still retain their ordering in the container their in until
 //! they are made visible again.
 //!
+//! A container whose children are all invisible is not laid out either.
+//! [`Tiles::is_visible`] reports the flag you set yourself, while
+//! [`Tiles::is_visible_in_layout`] reports what actually gets space.
+//!
 //! ## Shares
 //! The relative sizes of linear layout (horizontal or vertical) and grid columns and rows are specified by _shares_.
 //! If the shares are `1,2,3` it means the first element gets `1/6` of the space, the second `2/6`, and the third `3/6`.

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -102,7 +102,7 @@ impl<Pane> Tiles<Pane> {
     ///
     /// If the tile isn't visible, or is in an inactive tab, this return `None`.
     pub fn rect(&self, tile_id: TileId) -> Option<Rect> {
-        if self.is_visible(tile_id) {
+        if self.is_visible_in_layout(tile_id) {
             self.rects.get(&tile_id).copied()
         } else {
             None
@@ -147,6 +147,31 @@ impl<Pane> Tiles<Pane> {
         !self.invisible.contains(&tile_id)
     }
 
+    /// Is this tile given any space in the layout?
+    ///
+    /// Like [`Self::is_visible`], except a container whose children are all invisible is
+    /// skipped too: it would take up space to show nothing.
+    ///
+    /// An empty container hides nothing and is still a drop target, so it keeps its space.
+    pub fn is_visible_in_layout(&self, tile_id: TileId) -> bool {
+        if !self.is_visible(tile_id) {
+            return false;
+        }
+
+        let Some(Tile::Container(container)) = self.get(tile_id) else {
+            return true;
+        };
+
+        let mut has_children = false;
+        for &child_id in container.children() {
+            has_children = true;
+            if self.is_visible_in_layout(child_id) {
+                return true;
+            }
+        }
+        !has_children
+    }
+
     /// Tiles are visible by default.
     ///
     /// Invisible tiles still retain their place in the tile hierarchy.
@@ -164,7 +189,7 @@ impl<Pane> Tiles<Pane> {
 
     /// This excludes all tiles that are invisible or are inactive tabs, recursively.
     pub(crate) fn collect_active_tiles(&self, tile_id: TileId, tiles: &mut Vec<TileId>) {
-        if !self.is_visible(tile_id) {
+        if !self.is_visible_in_layout(tile_id) {
             return;
         }
         tiles.push(tile_id);
@@ -1025,6 +1050,67 @@ mod tests {
                 "the user was looking at `b` through the flattened container, so `b` stays open"
             );
         }
+    }
+
+    /// A tab container whose only pane is hidden has nothing left to show, so it should get no
+    /// space of its own. Showing the pane again should bring the container back.
+    #[test]
+    fn a_container_with_nothing_to_show_is_not_laid_out() {
+        let mut tiles = Tiles::default();
+        let pane = tiles.insert_pane("a");
+        let tabs = tiles.insert_tab_tile(vec![pane]);
+
+        assert!(tiles.is_visible_in_layout(tabs));
+
+        tiles.set_visible(pane, false);
+        assert!(
+            !tiles.is_visible_in_layout(tabs),
+            "the tab container has only a hidden pane left to show"
+        );
+        assert!(
+            tiles.is_visible(tabs),
+            "the container itself was never hidden, and asking for the flag should say so"
+        );
+
+        tiles.set_visible(pane, true);
+        assert!(
+            tiles.is_visible_in_layout(tabs),
+            "showing the pane again should bring back the container around it"
+        );
+    }
+
+    /// Nothing visible anywhere in the subtree means nothing to lay out, however deep it is.
+    #[test]
+    fn hiding_the_only_pane_hides_every_container_above_it() {
+        let mut tiles = Tiles::default();
+        let pane = tiles.insert_pane("a");
+        let tabs = tiles.insert_tab_tile(vec![pane]);
+        let inner = tiles.insert_horizontal_tile(vec![tabs]);
+        let outer = tiles.insert_vertical_tile(vec![inner]);
+
+        tiles.set_visible(pane, false);
+
+        for tile_id in [tabs, inner, outer] {
+            assert!(
+                !tiles.is_visible_in_layout(tile_id),
+                "{tile_id:?} has nothing but the hidden pane below it"
+            );
+        }
+    }
+
+    /// An empty container is not hiding anything, and it is still a place to drop tiles into,
+    /// so it keeps its space.
+    #[test]
+    fn an_empty_container_keeps_its_space() {
+        let mut tiles = Tiles::<&str>::default();
+        let empty = tiles.insert_tab_tile(vec![]);
+        assert!(tiles.is_visible_in_layout(empty));
+
+        tiles.set_visible(empty, false);
+        assert!(
+            !tiles.is_visible_in_layout(empty),
+            "hiding it explicitly still hides it"
+        );
     }
 
     /// Inserting into a container that already accepts the tile must not wrap anything.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -266,6 +266,13 @@ impl<Pane> Tree<Pane> {
         self.tiles.is_visible(tile_id)
     }
 
+    /// Is this tile given any space in the layout?
+    ///
+    /// See [`Tiles::is_visible_in_layout`].
+    pub fn is_visible_in_layout(&self, tile_id: TileId) -> bool {
+        self.tiles.is_visible_in_layout(tile_id)
+    }
+
     /// Tiles are visible by default.
     ///
     /// Invisible tiles still retain their place in the tile hierarchy.
@@ -275,14 +282,13 @@ impl<Pane> Tree<Pane> {
 
     /// All visible tiles.
     ///
-    /// This excludes all tiles that are invisible or are inactive tabs, recursively.
+    /// This excludes all tiles that are invisible or are inactive tabs, recursively,
+    /// as well as containers left with nothing visible to show.
     ///
     /// The order of the returned tiles is arbitrary.
     pub fn active_tiles(&self) -> Vec<TileId> {
         let mut tiles = vec![];
-        if let Some(root) = self.root
-            && self.is_visible(root)
-        {
+        if let Some(root) = self.root {
             self.tiles.collect_active_tiles(root, &mut tiles);
         }
         tiles
@@ -371,7 +377,7 @@ impl<Pane> Tree<Pane> {
         ui: &Ui,
         tile_id: TileId,
     ) {
-        if !self.is_visible(tile_id) {
+        if !self.is_visible_in_layout(tile_id) {
             return;
         }
         // NOTE: important that we get the rect and tile in two steps,

--- a/tests/hidden_tiles.rs
+++ b/tests/hidden_tiles.rs
@@ -1,0 +1,140 @@
+//! Hiding a tile should free up the space it took, all the way up through the containers that
+//! held nothing else.
+//!
+//! `all_panes_must_have_tabs` is what makes this easy to get wrong: every pane sits alone in a
+//! tab container, so hiding the pane leaves the tab container as the thing occupying the slot.
+
+use egui_tiles::{Behavior, SimplificationOptions, Tile, TileId, Tiles, Tree, UiResponse};
+
+struct TestBehavior;
+
+impl Behavior<&'static str> for TestBehavior {
+    fn pane_ui(&mut self, ui: &mut egui::Ui, _id: TileId, pane: &mut &'static str) -> UiResponse {
+        ui.label(*pane);
+        UiResponse::None
+    }
+
+    fn tab_title_for_pane(&mut self, pane: &&'static str) -> egui::WidgetText {
+        (*pane).into()
+    }
+
+    fn simplification_options(&self) -> SimplificationOptions {
+        SimplificationOptions {
+            all_panes_must_have_tabs: true,
+            ..Default::default()
+        }
+    }
+}
+
+const VIEWPORT: egui::Vec2 = egui::vec2(800.0, 600.0);
+
+/// Two panes side by side, each wrapped in its own tab container by `all_panes_must_have_tabs`.
+fn harness() -> egui_kittest::Harness<'static, Tree<&'static str>> {
+    let mut tiles = Tiles::default();
+    let a = tiles.insert_pane("a");
+    let b = tiles.insert_pane("b");
+    let root = tiles.insert_horizontal_tile(vec![a, b]);
+    let tree = Tree::new("test", root, tiles);
+
+    let mut harness = egui_kittest::Harness::builder()
+        .with_size(VIEWPORT)
+        .build_ui_state(
+            |ui, tree: &mut Tree<&'static str>| {
+                tree.ui(&mut TestBehavior, ui);
+            },
+            tree,
+        );
+    harness.run();
+    harness
+}
+
+/// The pane with the given name, or `None` if it is gone.
+fn pane(tree: &Tree<&'static str>, name: &str) -> Option<TileId> {
+    tree.tiles
+        .iter()
+        .find(|(_, tile)| matches!(tile, Tile::Pane(pane) if *pane == name))
+        .map(|(tile_id, _)| *tile_id)
+}
+
+/// The width the pane's slot takes up in the root container, tab bar and all.
+fn slot_width(tree: &Tree<&'static str>, name: &str) -> f32 {
+    let pane_id = pane(tree, name).expect("the pane should still be in the tree");
+    let slot = tree
+        .tiles
+        .parent_of(pane_id)
+        .expect("`all_panes_must_have_tabs` should have given the pane a tab container");
+    tree.tiles.rect(slot).map_or(0.0, |rect| rect.width())
+}
+
+/// The width the whole tree was laid out in.
+fn tree_width(tree: &Tree<&'static str>) -> f32 {
+    tree.tiles
+        .rect(tree.root().expect("the tree should have a root"))
+        .expect("the root should have been laid out")
+        .width()
+}
+
+#[test]
+fn hiding_a_pane_gives_its_space_to_its_sibling() {
+    let mut harness = harness();
+
+    let whole_width = tree_width(harness.state());
+    let split_width = slot_width(harness.state(), "b");
+    assert!(
+        split_width < whole_width / 2.0 + 1.0,
+        "the two panes should share the width to begin with, but `b` got {split_width} \
+         out of {whole_width}"
+    );
+
+    let hidden = pane(harness.state(), "a").expect("pane `a`");
+    harness.state_mut().set_visible(hidden, false);
+    harness.run();
+
+    let full_width = slot_width(harness.state(), "b");
+    assert!(
+        full_width > whole_width - 1.0,
+        "`b` is the only thing left to show, so it should have the whole width of \
+         {whole_width}, but got {full_width}"
+    );
+    assert_eq!(
+        slot_width(harness.state(), "a"),
+        0.0,
+        "the tab container around the hidden pane should not be laid out"
+    );
+
+    harness.state_mut().set_visible(hidden, true);
+    harness.run();
+
+    assert!(
+        (slot_width(harness.state(), "b") - split_width).abs() < 1.0,
+        "showing the pane again should restore the split"
+    );
+}
+
+/// A tile that shows nothing is not among the active tiles either, so an app asking what the
+/// user can see does not hear about the container wrapped around a hidden pane.
+#[test]
+fn a_hidden_pane_leaves_no_active_tiles_behind() {
+    let mut harness = harness();
+
+    let hidden = pane(harness.state(), "a").expect("pane `a`");
+    harness.state_mut().set_visible(hidden, false);
+    harness.run();
+
+    let tree = harness.state();
+    let active = tree.active_tiles();
+    let visible_panes: Vec<_> = active
+        .iter()
+        .filter_map(|&tile_id| match tree.tiles.get(tile_id) {
+            Some(Tile::Pane(pane)) => Some(*pane),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(visible_panes, vec!["b"]);
+    assert!(
+        !active.contains(&hidden)
+            && !active.contains(&tree.tiles.parent_of(hidden).expect("the tab container")),
+        "neither the hidden pane nor the container around it is active: {active:?}"
+    );
+}

--- a/tests/hidden_tiles.rs
+++ b/tests/hidden_tiles.rs
@@ -28,6 +28,9 @@ impl Behavior<&'static str> for TestBehavior {
 
 const VIEWPORT: egui::Vec2 = egui::vec2(800.0, 600.0);
 
+/// What `TestBehavior` leaves between two tiles, since it keeps the default `Behavior::gap_width`.
+const GAP_WIDTH: f32 = 1.0;
+
 /// Two panes side by side, each wrapped in its own tab container by `all_panes_must_have_tabs`.
 fn harness() -> egui_kittest::Harness<'static, Tree<&'static str>> {
     let mut tiles = Tiles::default();
@@ -56,14 +59,22 @@ fn pane(tree: &Tree<&'static str>, name: &str) -> Option<TileId> {
         .map(|(tile_id, _)| *tile_id)
 }
 
-/// The width the pane's slot takes up in the root container, tab bar and all.
-fn slot_width(tree: &Tree<&'static str>, name: &str) -> f32 {
+/// The rect the pane's slot in the root container was laid out in, tab bar and all,
+/// or `None` if it was never laid out.
+fn slot_rect(tree: &Tree<&'static str>, name: &str) -> Option<egui::Rect> {
     let pane_id = pane(tree, name).expect("the pane should still be in the tree");
     let slot = tree
         .tiles
         .parent_of(pane_id)
         .expect("`all_panes_must_have_tabs` should have given the pane a tab container");
-    tree.tiles.rect(slot).map_or(0.0, |rect| rect.width())
+    tree.tiles.rect(slot)
+}
+
+/// The width the pane's slot takes up in the root container, tab bar and all.
+fn slot_width(tree: &Tree<&'static str>, name: &str) -> f32 {
+    slot_rect(tree, name)
+        .expect("the slot should have been laid out")
+        .width()
 }
 
 /// The width the whole tree was laid out in.
@@ -79,34 +90,34 @@ fn hiding_a_pane_gives_its_space_to_its_sibling() {
     let mut harness = harness();
 
     let whole_width = tree_width(harness.state());
-    let split_width = slot_width(harness.state(), "b");
-    assert!(
-        split_width < whole_width / 2.0 + 1.0,
-        "the two panes should share the width to begin with, but `b` got {split_width} \
-         out of {whole_width}"
+    let split_width = (whole_width - GAP_WIDTH) / 2.0;
+    assert_eq!(
+        slot_width(harness.state(), "b"),
+        split_width,
+        "the two panes should split the {whole_width} the tree was laid out in"
     );
 
     let hidden = pane(harness.state(), "a").expect("pane `a`");
     harness.state_mut().set_visible(hidden, false);
     harness.run();
 
-    let full_width = slot_width(harness.state(), "b");
-    assert!(
-        full_width > whole_width - 1.0,
-        "`b` is the only thing left to show, so it should have the whole width of \
-         {whole_width}, but got {full_width}"
+    assert_eq!(
+        slot_width(harness.state(), "b"),
+        whole_width,
+        "`b` is the only thing left to show, so it should have the whole width"
     );
     assert_eq!(
-        slot_width(harness.state(), "a"),
-        0.0,
+        slot_rect(harness.state(), "a"),
+        None,
         "the tab container around the hidden pane should not be laid out"
     );
 
     harness.state_mut().set_visible(hidden, true);
     harness.run();
 
-    assert!(
-        (slot_width(harness.state(), "b") - split_width).abs() < 1.0,
+    assert_eq!(
+        slot_width(harness.state(), "b"),
+        split_width,
         "showing the pane again should restore the split"
     );
 }

--- a/tests/hidden_tiles.rs
+++ b/tests/hidden_tiles.rs
@@ -135,6 +135,6 @@ fn a_hidden_pane_leaves_no_active_tiles_behind() {
     assert!(
         !active.contains(&hidden)
             && !active.contains(&tree.tiles.parent_of(hidden).expect("the tab container")),
-        "neither the hidden pane nor the container around it is active: {active:?}"
+        "neither the hidden pane nor the container around it should be active: {active:?}"
     );
 }


### PR DESCRIPTION
Fixes tiles not disappearing in the layout after they've been hidden:

https://github.com/user-attachments/assets/80eed7ec-696f-4fd3-a244-9ce5be72c3b6
(video of bug)

So this makes container's size zero when their children are hidden.