### PR TITLE
Ctrl+Tab cycles the active tab of the hovered tab container

### DIFF
--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -17,7 +17,7 @@ pub enum EditAction {
     /// A tile was dropped and its position changed accordingly.
     TileDropped,
 
-    /// A tab was selected by a click, or by hovering a dragged tile over it,
+    /// A tab was selected by a click, by a keyboard shortcut, or by hovering a dragged tile over it,
     /// or there was no active tab and egui picked an arbitrary one.
     TabSelected,
 }
@@ -553,6 +553,15 @@ pub trait Behavior<Pane> {
     ///
     /// Default: `true` (all containers are resizable).
     fn is_container_resizable(&self, _tiles: &Tiles<Pane>, _tile_id: TileId) -> bool {
+        true
+    }
+
+    /// Should `Ctrl+Tab` and `Ctrl+Shift+Tab` cycle the active tab of the hovered tab container?
+    ///
+    /// The innermost [`crate::Tabs`] container under the pointer is the one that cycles.
+    ///
+    /// Default: `true`.
+    fn cycle_tabs_with_keyboard(&self) -> bool {
         true
     }
 

--- a/src/container/tabs.rs
+++ b/src/container/tabs.rs
@@ -174,6 +174,41 @@ impl Tabs {
         Some(child) == self.active
     }
 
+    /// Make the tab after (or before) the active one the active tab, wrapping around at the ends.
+    ///
+    /// Hidden tabs are skipped.
+    /// If no tab is active, the first (or last) visible tab is activated.
+    ///
+    /// Returns `true` if the active tab changed.
+    pub fn cycle_active<Pane>(&mut self, tiles: &Tiles<Pane>, forward: bool) -> bool {
+        let visible: Vec<TileId> = self
+            .children
+            .iter()
+            .copied()
+            .filter(|&child_id| tiles.is_visible_in_layout(child_id))
+            .collect();
+
+        let Some(last) = visible.len().checked_sub(1) else {
+            return false;
+        };
+
+        let current = self
+            .active
+            .and_then(|active| visible.iter().position(|&child_id| child_id == active));
+
+        let next = match (current, forward) {
+            (None, true) => 0,
+            (None, false) => last,
+            (Some(index), true) => (index + 1) % visible.len(),
+            (Some(index), false) => index.checked_sub(1).unwrap_or(last),
+        };
+
+        let new_active = Some(visible[next]);
+        let changed = new_active != self.active;
+        self.active = new_active;
+        changed
+    }
+
     pub(super) fn layout<Pane>(
         &mut self,
         tiles: &mut Tiles<Pane>,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,4 +1,4 @@
-use egui::{NumExt as _, Rect, Ui};
+use egui::{Key, Modifiers, NumExt as _, Rect, Ui};
 
 use crate::behavior::{EditAction, layout_tiles};
 use crate::{ContainerInsertion, ContainerKind, UiResponse};
@@ -343,7 +343,51 @@ impl<Pane> Tree<Pane> {
         }
 
         self.preview_dragged_tile(behavior, &drop_context, ui);
+        self.handle_tab_cycle_shortcuts(behavior, ui);
         ui.advance_cursor_after_rect(rect);
+    }
+
+    /// `Ctrl+Tab` / `Ctrl+Shift+Tab` cycles the active tab of the innermost hovered tab container.
+    ///
+    /// Must run after the tiles have been shown, so the new active tab takes effect next frame,
+    /// same as when a tab is clicked.
+    fn handle_tab_cycle_shortcuts(&mut self, behavior: &mut dyn Behavior<Pane>, ui: &Ui) {
+        if !behavior.cycle_tabs_with_keyboard() {
+            return;
+        }
+
+        let hovered_tabs = self
+            .tiles
+            .iter()
+            .filter(|(_, tile)| matches!(tile, Tile::Container(Container::Tabs(_))))
+            .filter_map(|(&tile_id, _)| Some((tile_id, self.tiles.rect(tile_id)?)))
+            .filter(|(_, rect)| ui.rect_contains_pointer(*rect))
+            .min_by(|(_, a), (_, b)| a.area().total_cmp(&b.area()))
+            .map(|(tile_id, _)| tile_id);
+
+        let Some(tabs_id) = hovered_tabs else {
+            return;
+        };
+
+        // Check the more specific shortcut first: `consume_key` ignores extra Shift.
+        let forward =
+            if ui.input_mut(|i| i.consume_key(Modifiers::CTRL | Modifiers::SHIFT, Key::Tab)) {
+                false
+            } else if ui.input_mut(|i| i.consume_key(Modifiers::CTRL, Key::Tab)) {
+                true
+            } else {
+                return;
+            };
+
+        let Some(mut tile) = self.tiles.remove(tabs_id) else {
+            return;
+        };
+        if let Tile::Container(Container::Tabs(tabs)) = &mut tile
+            && tabs.cycle_active(&self.tiles, forward)
+        {
+            behavior.on_edit(EditAction::TabSelected);
+        }
+        self.tiles.insert(tabs_id, tile);
     }
 
     /// Sets the exact height that can be used by the tree.

--- a/tests/tab_cycle_shortcuts.rs
+++ b/tests/tab_cycle_shortcuts.rs
@@ -1,0 +1,127 @@
+//! `Ctrl+Tab` and `Ctrl+Shift+Tab` cycle the active tab of the hovered tab container.
+
+use egui::{Key, Modifiers};
+use egui_tiles::{Behavior, Container, Tile, TileId, Tiles, Tree, UiResponse};
+
+struct TestBehavior;
+
+impl Behavior<&'static str> for TestBehavior {
+    fn pane_ui(&mut self, ui: &mut egui::Ui, _id: TileId, pane: &mut &'static str) -> UiResponse {
+        ui.label(*pane);
+        UiResponse::None
+    }
+
+    fn tab_title_for_pane(&mut self, pane: &&'static str) -> egui::WidgetText {
+        (*pane).into()
+    }
+}
+
+const VIEWPORT: egui::Vec2 = egui::vec2(800.0, 600.0);
+
+/// A tab container with three panes, `a` active, shown in a viewport of [`VIEWPORT`] size.
+fn harness() -> egui_kittest::Harness<'static, Tree<&'static str>> {
+    let mut tiles = Tiles::default();
+    let a = tiles.insert_pane("a");
+    let b = tiles.insert_pane("b");
+    let c = tiles.insert_pane("c");
+    let root = tiles.insert_tab_tile(vec![a, b, c]);
+    let tree = Tree::new("test", root, tiles);
+
+    let mut harness = egui_kittest::Harness::builder()
+        .with_size(VIEWPORT)
+        .build_ui_state(
+            |ui, tree: &mut Tree<&'static str>| {
+                tree.ui(&mut TestBehavior, ui);
+            },
+            tree,
+        );
+    harness.run();
+    harness
+}
+
+/// The name of the active tab of the root tab container.
+fn active_tab(tree: &Tree<&'static str>) -> &'static str {
+    let root = tree.root().expect("the tree should have a root");
+    let Some(Tile::Container(Container::Tabs(tabs))) = tree.tiles.get(root) else {
+        panic!("the root should be a tab container");
+    };
+    let active = tabs.active.expect("a tab should be active");
+    match tree.tiles.get(active) {
+        Some(Tile::Pane(pane)) => pane,
+        other => panic!("expected a pane, got {other:?}"),
+    }
+}
+
+fn pane(tree: &Tree<&'static str>, name: &str) -> TileId {
+    tree.tiles
+        .iter()
+        .find(|(_, tile)| matches!(tile, Tile::Pane(pane) if *pane == name))
+        .map(|(tile_id, _)| *tile_id)
+        .expect("the pane should be in the tree")
+}
+
+#[test]
+fn ctrl_tab_cycles_forward_and_wraps() {
+    let mut harness = harness();
+    harness.hover_at(VIEWPORT.to_pos2() / 2.0);
+    harness.run();
+    assert_eq!(active_tab(harness.state()), "a");
+
+    for expected in ["b", "c", "a"] {
+        harness.key_press_modifiers(Modifiers::CTRL, Key::Tab);
+        harness.run();
+        assert_eq!(active_tab(harness.state()), expected);
+    }
+}
+
+#[test]
+fn ctrl_shift_tab_cycles_backward_and_wraps() {
+    let mut harness = harness();
+    harness.hover_at(VIEWPORT.to_pos2() / 2.0);
+    harness.run();
+
+    for expected in ["c", "b", "a"] {
+        harness.key_press_modifiers(Modifiers::CTRL | Modifiers::SHIFT, Key::Tab);
+        harness.run();
+        assert_eq!(active_tab(harness.state()), expected);
+    }
+}
+
+#[test]
+fn cycling_skips_hidden_tabs() {
+    let mut harness = harness();
+    let hidden = pane(harness.state(), "b");
+    harness.state_mut().set_visible(hidden, false);
+    harness.hover_at(VIEWPORT.to_pos2() / 2.0);
+    harness.run();
+
+    harness.key_press_modifiers(Modifiers::CTRL, Key::Tab);
+    harness.run();
+    assert_eq!(
+        active_tab(harness.state()),
+        "c",
+        "the hidden `b` should be skipped"
+    );
+}
+
+#[test]
+fn plain_tab_leaves_the_active_tab_alone() {
+    let mut harness = harness();
+    harness.hover_at(VIEWPORT.to_pos2() / 2.0);
+    harness.run();
+
+    harness.key_press(Key::Tab);
+    harness.run();
+    assert_eq!(active_tab(harness.state()), "a");
+}
+
+#[test]
+fn ctrl_tab_does_nothing_when_the_pointer_is_elsewhere() {
+    let mut harness = harness();
+    harness.hover_at(egui::pos2(-10.0, -10.0));
+    harness.run();
+
+    harness.key_press_modifiers(Modifiers::CTRL, Key::Tab);
+    harness.run();
+    assert_eq!(active_tab(harness.state()), "a");
+}


### PR DESCRIPTION
`Ctrl+Tab` activates the next tab and `Ctrl+Shift+Tab` the previous one, wrapping around and skipping hidden tabs. The innermost `Tabs` container under the pointer is the one that cycles. Plain `Tab` is left alone for egui focus navigation.

Opt out with `Behavior::cycle_tabs_with_keyboard`. Adds `Tabs::cycle_active` for callers who want to drive it themselves.
